### PR TITLE
🎨 style: middle size Button 컴포넌트 height 수정

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -15,7 +15,7 @@ export default function Button({
 }: Props) {
   return (
     <button
-      className={`rounded-md disabled:border-none disabled:bg-gray-40 disabled:text-white ${solid ? 'bg-primary text-white' : 'border border-primary bg-white text-primary'} ${size === 'large' ? 'h-48 text-body1 font-bold' : size === 'medium' ? 'h-37 text-body2 font-bold' : 'h-32 text-caption font-regular'} ${className}`}
+      className={`rounded-md disabled:border-none disabled:bg-gray-40 disabled:text-white ${solid ? 'bg-primary text-white' : 'border border-primary bg-white text-primary'} ${size === 'large' ? 'h-48 text-body1 font-bold' : size === 'medium' ? 'h-38 text-body2 font-bold' : 'h-32 text-caption font-regular'} ${className}`}
       type={type}
       {...props}
     >


### PR DESCRIPTION
## 📌 변경 사항 개요

Button 컴포넌트의 middle size 높이를 수정하였습니다.

## 📝 상세 내용

figma의 리소스 (공통 컴포넌트) 정리에서는 middle size의 height가 37px로 되어있어 그대로 했는데 실제 사용 figma를 확인해보니 계속 38px로 되어있어 높이를 수정하였습니다.

공통 컴포넌트
![image](https://github.com/user-attachments/assets/66f9d697-95e6-46cf-a9a2-8dd1ac37ee7a)

실사용
![image](https://github.com/user-attachments/assets/4540942e-3227-4aa9-ae54-8d352edc129c)
![image](https://github.com/user-attachments/assets/71a9bc9b-7048-45ed-b789-57b60e0b565d)
![image](https://github.com/user-attachments/assets/2651635e-aa9b-41a8-9fb5-472f6b2b32ea)


## 🔗 관련 이슈

Resolves: #39 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항