### PR TITLE
✨ feat: 로그인 및 회원가입 로직 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 const publicPaths = ['/login', '/signup'];
 
 const api = axios.create({
-  baseURL: 'https://bootcamp-api.codeit.kr/api/0-1/the-julge', // 공통 prefix
+  baseURL: 'https://bootcamp-api.codeit.kr/api/15-6/the-julge', // 공통 prefix
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,8 @@ function isPublicRequest(method?: string, url?: string): boolean {
     method === 'get' &&
       (
         url?.startsWith('/notices') ||
-        url?.startsWith('/shops')
+        url?.startsWith('/shops') ||
+        (/^\/users\/[^/]+$/.test(url)) // '/users/{id}' 형태만 허용 ('/users/{id}/alert' = X)
       )) ||
     (method === 'post' &&
       (

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+const publicPaths = ['/login', '/signup'];
+
 const api = axios.create({
   baseURL: 'https://bootcamp-api.codeit.kr/api/0-1/the-julge', // 공통 prefix
   headers: {
@@ -11,7 +13,8 @@ const api = axios.create({
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('accessToken');
-    if (token) {
+    const isPublic = publicPaths.some((path) => config.url?.includes(path));
+    if (!isPublic && token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,7 +9,9 @@ const api = axios.create({
 
 // 가독성을 위해 prettier-ignore 적용
 //prettier-ignore
-function isPublicRequest(method: string, url: string): boolean {
+function isPublicRequest(method?: string, url?: string): boolean {
+  if (!method || !url) return false;
+
   return (
     method === 'get' &&
       (

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,9 +9,7 @@ const api = axios.create({
 
 // 가독성을 위해 prettier-ignore 적용
 //prettier-ignore
-function isPublicRequest(method?: string, url?: string): boolean {
-  if (!method || !url) return false;
-
+function isPublicRequest(method: string, url: string): boolean {
   return (
     method === 'get' &&
       (

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -7,7 +7,6 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: false,
 });
 
 api.interceptors.request.use(

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'https://bootcamp-api.codeit.kr/api/0-1/the-julge', // 공통 prefix
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: false,
+});
+
+export default api;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,5 @@
 import axios from 'axios';
 
-const publicPaths = ['/login', '/signup'];
-
 const api = axios.create({
   baseURL: 'https://bootcamp-api.codeit.kr/api/15-6/the-julge', // 공통 prefix
   headers: {
@@ -9,10 +7,31 @@ const api = axios.create({
   },
 });
 
+// 가독성을 위해 prettier-ignore 적용
+//prettier-ignore
+function isPublicRequest(method?: string, url?: string): boolean {
+  if (!method || !url) return false;
+
+  return (
+    method === 'get' &&
+      (
+        url?.startsWith('/notices') ||
+        url?.startsWith('/shops')
+      )) ||
+    (method === 'post' &&
+      (
+        url === '/token' ||
+        url === '/users'
+      )
+    );
+}
+
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('accessToken');
-    const isPublic = publicPaths.some((path) => config.url?.includes(path));
+    const { url, method } = config;
+
+    const isPublic = isPublicRequest(method, url);
     if (!isPublic && token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -8,4 +8,15 @@ const api = axios.create({
   withCredentials: false,
 });
 
+api.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
 export default api;

--- a/src/api/getAlerts.ts
+++ b/src/api/getAlerts.ts
@@ -1,0 +1,71 @@
+import api from './api';
+import { AxiosError } from 'axios';
+
+interface ErrorMessage {
+  message: string;
+}
+
+interface AlertItem {
+  item: {
+    id: string;
+    createdAt: string;
+    result: 'accepted' | 'rejected';
+    read: boolean;
+    application: {
+      item: {
+        id: string;
+        status: 'pending' | 'accepted' | 'rejected';
+      };
+      href: string;
+    };
+    shop: {
+      item: {
+        id: string;
+        name: string;
+        category: string;
+        address1: string;
+        address2: string;
+        description: string;
+        imageUrl: string;
+        originalHourlyPay: number;
+      };
+      href: string;
+    };
+    notice: {
+      item: {
+        id: string;
+        hourlyPay: number;
+        description: string;
+        startsAt: string;
+        workhour: number;
+        closed: boolean;
+      };
+      href: string;
+    };
+    links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
+  };
+  links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
+}
+
+interface AlertsResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: AlertItem[];
+}
+
+export const getAlerts = async (userId: string): Promise<AlertsResponse> => {
+  try {
+    const response = await api.get<AlertsResponse>(`/users/${userId}/alerts`);
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/postToken.ts
+++ b/src/api/postToken.ts
@@ -1,0 +1,51 @@
+import api from './api';
+import { AxiosError } from 'axios';
+
+interface LoginParams {
+  email: string;
+  password: string;
+}
+
+interface LoginResponse {
+  item: {
+    token: string;
+    user: {
+      item: {
+        id: string;
+        email: string;
+        type: string;
+        name: string;
+        phone: string;
+        address: string;
+        bio: string;
+      };
+      href: string;
+    };
+  };
+  links: any[];
+}
+
+interface ErrorResponse {
+  message: string;
+}
+
+export const postToken = async ({
+  email,
+  password,
+}: LoginParams): Promise<LoginResponse> => {
+  try {
+    const response = await api.post('/token', {
+      email,
+      password,
+    });
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorResponse>;
+
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/postToken.ts
+++ b/src/api/postToken.ts
@@ -17,7 +17,7 @@ interface LoginResponse {
       item: {
         id: string;
         email: string;
-        type: employer | employee;
+        type: 'employer' | 'employee';
         name: string;
         phone: string;
         address: string;

--- a/src/api/postToken.ts
+++ b/src/api/postToken.ts
@@ -34,13 +34,13 @@ export const postToken = async ({
   password,
 }: LoginParams): Promise<LoginResponse> => {
   try {
-    const response = await api.post('/token', {
+    const response = await api.post<LoginResponse>('/token', {
       email,
       password,
     });
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage, LoginParams>;
+    const axiosError = error as AxiosError<ErrorMessage, LoginParams>; // 에러 타입 명시
     if (axiosError.response) {
       throw new Error(axiosError.response.data.message);
     } else {

--- a/src/api/postToken.ts
+++ b/src/api/postToken.ts
@@ -1,6 +1,10 @@
 import api from './api';
 import { AxiosError } from 'axios';
 
+interface ErrorMessage {
+  message: string;
+}
+
 interface LoginParams {
   email: string;
   password: string;
@@ -13,7 +17,7 @@ interface LoginResponse {
       item: {
         id: string;
         email: string;
-        type: string;
+        type: employer | employee;
         name: string;
         phone: string;
         address: string;
@@ -22,11 +26,7 @@ interface LoginResponse {
       href: string;
     };
   };
-  links: any[];
-}
-
-interface ErrorResponse {
-  message: string;
+  links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
 }
 
 export const postToken = async ({
@@ -40,8 +40,7 @@ export const postToken = async ({
     });
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorResponse>;
-
+    const axiosError = error as AxiosError<ErrorMessage, LoginParams>;
     if (axiosError.response) {
       throw new Error(axiosError.response.data.message);
     } else {

--- a/src/api/postUser.ts
+++ b/src/api/postUser.ts
@@ -8,14 +8,14 @@ interface ErrorMessage {
 interface SignupParams {
   email: string;
   password: string;
-  type: employee | employer;
+  type: 'employee' | 'employer';
 }
 
 interface SignupResponse {
   item: {
     id: string;
     email: string;
-    type: employee | employer;
+    type: 'employee' | 'employer';
   };
   links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
 }

--- a/src/api/postUser.ts
+++ b/src/api/postUser.ts
@@ -1,0 +1,30 @@
+import type { ErrorResponse } from 'react-router-dom';
+import api from './api';
+import { AxiosError } from 'axios';
+
+export const postUser = async ({
+  email,
+  password,
+  type,
+}: {
+  email: string;
+  password: string;
+  type: string;
+}) => {
+  try {
+    const response = await api.post('/users', {
+      email,
+      password,
+      type,
+    });
+
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorResponse>;
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/postUser.ts
+++ b/src/api/postUser.ts
@@ -8,10 +8,23 @@ interface ErrorMessage {
 interface SignupParams {
   email: string;
   password: string;
-  type: string;
+  type: employee | employer;
 }
 
-export const postUser = async ({ email, password, type }: SignupParams) => {
+interface SignupResponse {
+  item: {
+    id: string;
+    email: string;
+    type: employee | employer;
+  };
+  links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
+}
+
+export const postUser = async ({
+  email,
+  password,
+  type,
+}: SignupParams): Promise<SignupResponse> => {
   try {
     const response = await api.post('/users', {
       email,
@@ -20,7 +33,7 @@ export const postUser = async ({ email, password, type }: SignupParams) => {
     });
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+    const axiosError = error as AxiosError<ErrorMessage, SignupParams>; // 에러 타입 명시
     if (axiosError.response) {
       throw new Error(axiosError.response.data.message);
     } else {

--- a/src/api/postUser.ts
+++ b/src/api/postUser.ts
@@ -26,7 +26,7 @@ export const postUser = async ({
   type,
 }: SignupParams): Promise<SignupResponse> => {
   try {
-    const response = await api.post('/users', {
+    const response = await api.post<SignupResponse>('/users', {
       email,
       password,
       type,

--- a/src/api/postUser.ts
+++ b/src/api/postUser.ts
@@ -1,26 +1,26 @@
-import type { ErrorResponse } from 'react-router-dom';
 import api from './api';
 import { AxiosError } from 'axios';
 
-export const postUser = async ({
-  email,
-  password,
-  type,
-}: {
+interface ErrorMessage {
+  message: string;
+}
+
+interface SignupParams {
   email: string;
   password: string;
   type: string;
-}) => {
+}
+
+export const postUser = async ({ email, password, type }: SignupParams) => {
   try {
     const response = await api.post('/users', {
       email,
       password,
       type,
     });
-
     return response.data;
   } catch (error) {
-    const axiosError = error as AxiosError<ErrorResponse>;
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
     if (axiosError.response) {
       throw new Error(axiosError.response.data.message);
     } else {

--- a/src/components/common/notification-modal/NotificationModal.tsx
+++ b/src/components/common/notification-modal/NotificationModal.tsx
@@ -1,27 +1,50 @@
 import NotificationCard from './NotificationCard';
 import close from '@/assets/icons/close.svg';
 
-interface NotificationItem {
+interface AlertItem {
   item: {
-    id: string; // 가게 id
-    createdAt: string; // 생성 일시 (ISO 8601 문자열)
-    result: 'accepted' | 'rejected'; // 결과 상태
-    read: boolean; // 읽음 여부
+    id: string;
+    createdAt: string;
+    result: 'accepted' | 'rejected';
+    read: boolean;
+    application: {
+      item: {
+        id: string;
+        status: 'pending' | 'accepted' | 'rejected';
+      };
+      href: string;
+    };
     shop: {
       item: {
-        name: string; // 가게 이름
+        id: string;
+        name: string;
+        category: string;
+        address1: string;
+        address2: string;
+        description: string;
+        imageUrl: string;
+        originalHourlyPay: number;
       };
+      href: string;
     };
     notice: {
       item: {
-        startsAt: string; // 근무 시작 시간 (ISO 8601 문자열)
-        workhour: number; // 근무 시간 (시간 단위)
+        id: string;
+        hourlyPay: number;
+        description: string;
+        startsAt: string;
+        workhour: number;
+        closed: boolean;
       };
+      href: string;
     };
+    links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
   };
+  links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
 }
+
 interface NotificationModalProps {
-  data?: NotificationItem[]; // 알림 데이터 배열
+  data?: AlertsInfo[]; // 알림 데이터 배열
   count?: number; // 알림 개수
   onClose: () => void; // x 버튼을 누를때 실행할 함수
 }

--- a/src/components/common/notification-modal/NotificationModal.tsx
+++ b/src/components/common/notification-modal/NotificationModal.tsx
@@ -44,7 +44,7 @@ interface AlertItem {
 }
 
 interface NotificationModalProps {
-  data?: AlertsInfo[]; // 알림 데이터 배열
+  data?: AlertItem[]; // 알림 데이터 배열
   count?: number; // 알림 개수
   onClose: () => void; // x 버튼을 누를때 실행할 함수
 }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -32,6 +32,7 @@ interface AuthContextType {
   isLoggedIn: boolean; // 로그인 여부
   role: UserRole; // 알바님, 사장님 구분
   alarms: AlarmInfo; // 알림 리스트
+  login: (token: string, role: UserRole, userId: string) => void; // 로그인 함수
   logout: () => void; // 로그아웃 함수
 }
 
@@ -39,6 +40,7 @@ const defaultAuthContext: AuthContextType = {
   isLoggedIn: false,
   role: null,
   alarms: { count: 0, items: [] },
+  login: () => {},
   logout: () => {},
 };
 
@@ -49,7 +51,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [role, setRole] = useState<UserRole>(null);
   const [alarms, setAlarms] = useState<AlarmInfo>(defaultAuthContext.alarms);
 
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    const role = localStorage.getItem('userRole') as UserRole;
+    if (token && role) {
+      setIsLoggedIn(true);
+      setRole(role);
+    }
+  }, []);
+
+  const login = async (token: string, role: UserRole, userId: string) => {
+    localStorage.setItem('accessToken', token);
+    localStorage.setItem('userRole', role || '');
+    setIsLoggedIn(true);
+    setRole(role);
+    try {
+      const alertRes = await getAlerts(userId);
+      setAlarms(alertRes);
+      console.log('alertRes', alertRes);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   const logout = () => {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('userRole');
     setIsLoggedIn(false);
     setRole(null);
     setAlarms(defaultAuthContext.alarms);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -83,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ isLoggedIn, role, alarms, logout }}>
+    <AuthContext.Provider value={{ isLoggedIn, role, alarms, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -65,7 +65,7 @@ interface AuthContextType {
 const defaultAuthContext: AuthContextType = {
   isLoggedIn: false,
   role: null,
-  alarms: { count: 0, items: [] },
+  alarms: { offset: 0, limit: 0, count: 0, hasNext: false, items: [] },
   login: () => {},
   logout: () => {},
 };
@@ -75,7 +75,7 @@ export const AuthContext = createContext<AuthContextType>(defaultAuthContext);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [role, setRole] = useState<UserRole>(null);
-  const [alarms, setAlarms] = useState<AlarmInfo>(defaultAuthContext.alarms);
+  const [alarms, setAlarms] = useState<AlertsInfo>(defaultAuthContext.alarms);
 
   useEffect(() => {
     const token = localStorage.getItem('accessToken');

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,4 @@
-import { createContext, useState, useEffect } from 'react';
-import type { ReactNode } from 'react';
+import { createContext, useState, useEffect, type ReactNode } from 'react';
 import { getAlerts } from '@/api/getAlerts';
 
 type UserRole = 'employer' | 'employee' | null;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,37 +1,63 @@
-import { createContext, useState } from 'react';
+import { createContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
+import { getAlerts } from '@/api/getAlerts';
 
 type UserRole = 'employer' | 'employee' | null;
 
-interface AlarmType {
+interface AlertItem {
   item: {
-    id: string; // 가게 id
-    createdAt: string; // 생성 일시 (ISO 8601 문자열)
-    result: 'accepted' | 'rejected'; // 결과 상태
-    read: boolean; // 읽음 여부
+    id: string;
+    createdAt: string;
+    result: 'accepted' | 'rejected';
+    read: boolean;
+    application: {
+      item: {
+        id: string;
+        status: 'pending' | 'accepted' | 'rejected';
+      };
+      href: string;
+    };
     shop: {
       item: {
-        name: string; // 가게 이름
+        id: string;
+        name: string;
+        category: string;
+        address1: string;
+        address2: string;
+        description: string;
+        imageUrl: string;
+        originalHourlyPay: number;
       };
+      href: string;
     };
     notice: {
       item: {
-        startsAt: string; // 근무 시작 시간 (ISO 8601 문자열)
-        workhour: number; // 근무 시간 (시간 단위)
+        id: string;
+        hourlyPay: number;
+        description: string;
+        startsAt: string;
+        workhour: number;
+        closed: boolean;
       };
+      href: string;
     };
+    links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
   };
+  links: object[]; // 정확한 타입이 나와있지 않아서 우선 object로만 처리함
 }
 
-interface AlarmInfo {
+interface AlertsInfo {
+  offset: number;
+  limit: number;
   count: number;
-  items: AlarmType[];
+  hasNext: boolean;
+  items: AlertItem[];
 }
 
 interface AuthContextType {
   isLoggedIn: boolean; // 로그인 여부
   role: UserRole; // 알바님, 사장님 구분
-  alarms: AlarmInfo; // 알림 리스트
+  alarms: AlertsInfo; // 알림 정보
   login: (token: string, role: UserRole, userId: string) => void; // 로그인 함수
   logout: () => void; // 로그아웃 함수
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

로그인 및 회원가입 로직을 구현했습니다.
추가로, 로그인 로직에 알림을 받아오는 기능이 포함되어 있어, 알림 관련 로직도 함께 구현되었습니다.

- api 관련
  - 공통 Axios 인스턴스 설정 및  interceptor 설정 (Authorization 헤더 자동 주입) (`api/api.ts`)
  - 로그인 API 호출 로직 작성 (`api/postToken.ts`)
  - 회원가입 API 호출 로직 작성 (`api/postUser.ts`)
  - 알림 API 호출 로직 작성 (`api/getAlerts.ts`)
  
- 로그인 / 회원가입 로직
  - 로그인 및 로그아웃 함수 AuthContext 내에서 구현 (`context/AuthContext.tsx`)
  - 로그인 성공 시 localstorage에 accessToken 저장 (`context/AuthContext.tsx`)
  - 로그인 시 알림 불러오도록 구현 (`context/AuthContext.tsx`)
  
- ❗ 수정사항
  - 알림 response에 따라 알림 타입 수정 (`common/NotificationModal` , `context/AuthContext.tsx` )


## 📝 상세 내용

내용이 많아서 아래에 추가 및 수정된 주요 파일들에 대한 설명을 좀 덧붙이겠습니다~!

### api.ts
```ts
import axios from 'axios';

const api = axios.create({
  baseURL: 'https://bootcamp-api.codeit.kr/api/15-6/the-julge', // 공통 prefix
  headers: {
    'Content-Type': 'application/json',
  },
});
```
- baseURL, Content-Type, Authorization 헤더 등 기본 설정이 적용된 axios 인스턴스입니다.<br/>

  ```js
  import api from '@/api/api';

  api.get('/users'); // 자동으로 baseURL + /users로 요청됨
  ```
  API 요청은 axios 대신 이 api 인스턴스를 위처럼 사용하시면 됩니다
<br>

```ts
api.interceptors.request.use(
  (config) => {
    const token = localStorage.getItem('accessToken');
    const { url, method } = config;

    const isPublic = isPublicRequest(method, url);
    if (!isPublic && token) {
      config.headers.Authorization = `Bearer ${token}`;
    }
    return config;
  },
  (error) => Promise.reject(error),
);

export default api;
```
- axios 인스턴스가 api **요청을 보내기 전**에 실행될 함수입니다.
`(config) =>` 부분에서는 요청 전에 설정을 추가하며,<br> `(error) =>` 부분에서는 설정 중 오류 발생 시 실행됩니다.
- Authorize가 필요한 요청에 대해서 Authorization 헤더가 자동으로 설정되도록 설정했습니다.

  localStorage에 저장된 accessToken이 있으면, 자동으로 **Bearer 토큰을 요청 헤더에 추가**합니다.

```ts
function isPublicRequest(method?: string, url?: string): boolean {
  if (!method || !url) return false;

  return (
    method === 'get' &&
      (
        url?.startsWith('/notices') ||
        url?.startsWith('/shops') ||
        (/^\/users\/[^/]+$/.test(url)) // '/users/{id}' 형태만 허용 ('/users/{id}/alert' = X)
      )) ||
    (method === 'post' &&
      (
        url === '/token' ||
        url === '/users'
      )
    );
}
```
- 인증이 필요하지 않은 요청에 대해서는 **요청 헤더에 Bearer 토큰을 추가하지 않습니다**.
  Authorize가 필요하지 않은 요청은 아래와 같습니다.
  - get /notices
  - get /shops/{shop_id}/notices
  - get /shops/{shop_id}/notices/{notice_id}
  - get /shops/{shop_id}
  - get /shops/{shop_id}/notices/{notice_id}/applications
  - post /token
  - post /users
  - get /users/{user_id} : <s>내 정보 조회 요청이라, authorize가 필요할 것 같은데, swagger에는 포함되지 않아있음. api 오류인것 같아서 우선 제외하고 진행하였음 <br> -> 오늘(6/12) 주강사님께 질문 예정입니다~! 답변 받으면 수정하겠습니다~!</s><br> -> api 설계 자체는 로그인이 안된 상태로도 다른 회원의 프로필을 조회할 수 있게 설정되어 있어, authorize가 필요하지 않음. 다만, 피그마상에 해당 부분은 구현되어있지 않음. 따라서 우선 이 경로 요청도 isPublicRequest 함수에서 처리하도록 수정할 예정 -> **완료**

- isPublicRequest 함수에서 요청이 위 요청 중 하나라면 true, 위 요청이 아니라면 false를 반환합니다.
위 함수를 활용하여 함수의 리턴값이 false인 경우에만 bearer 토큰을 추가합니다.

  
### AuthContext.tsx
```tsx
  const login = async (token: string, role: UserRole, userId: string) => {
    localStorage.setItem('accessToken', token);
    localStorage.setItem('userRole', role || '');
    setIsLoggedIn(true);
    setRole(role);
    try {
      const alertRes = await getAlerts(userId);
      setAlarms(alertRes);
      console.log('alertRes', alertRes);
    } catch (error) {
      console.error(error);
    }
  };

  const logout = () => {
    localStorage.removeItem('accessToken');
    localStorage.removeItem('userRole');
    setIsLoggedIn(false);
    setRole(null);
    setAlarms(defaultAuthContext.alarms);
  };
```
- 로그인 함수 구현
  로그인 시 로컬스토리지에 해당 유저의 `accessToken`과 `role(employee | employer)`을 저장하며,
 api 호출을 통해 해당 유저의 알림 목록을 받아옵니다.

- 로그아웃 함수 구현
  로그아웃 시 로컬스토리지에서 `accessToken`과 `role`을 제거하며, 알림을 초기 상태로 초기화합니다.

```tsx
useEffect(() => {
    const token = localStorage.getItem('accessToken');
    const role = localStorage.getItem('userRole') as UserRole;
    if (token && role) {
      setIsLoggedIn(true);
      setRole(role);
    }
  }, []);
```
- 로그인한 상태로 새로고침 시 **로그인이 풀리는 문제를 방지**하기 위한 코드입니다.
- 초기 렌더링 시에 실행되며, 로컬스토리지에 토큰 및 role이 존재한다면 해당 정보를 가져와 로그인 상태를 유지합니다

### api 호출 함수들 - postUser.ts, postToken.ts, getAlerts.ts
- 세 함수 모두 요청 이후 받은 response의 data를 리턴합니다.
- try catch를 사용해 에러 발생시에 에러 메시지를 전달합니다.
- 이에 대한 에러 처리 부분은 사용하는 컴포넌트에서 구현될 예정이며, 토스트나 모달 등의 UI로 처리할 예정입니다.

## 🔗 관련 이슈

- #43 

## 🖼️ 스크린샷(선택사항)

회원가입 기능 테스트

https://github.com/user-attachments/assets/f9fcf46d-2e67-4daf-88bf-c30c7485d10d

로그인 기능 테스트

https://github.com/user-attachments/assets/79a7b592-b902-4968-a093-60d0d04d94ff

로그인 시 로컬스토리지에 accessToken과 userRole이 추가되며, 로그아웃 시 삭제됩니다.

## 💡 참고 사항
- 로그인/회원 가입은 처음 작업해보다 보니 이상한 점 발견되면 편하게 말씀주세요 😊
- 영상은 오직 로그인, 회원가입 기능에 대한 테스트이므로 ui 부분은 제맘대로 넣은것이니 신경쓰지 않으셔도 됩니다~!
- 테스트 페이지는 올리지 않았습니다.
- 리다이렉션은 다음 작업에 진행될 예정입니다.