### PR TITLE
🐛 fix: 알림 모달의 z-index를 일반 모달의 z-index(40)보다 낮게 30으로 수정

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -89,7 +89,7 @@ export default function Navbar() {
 
         {isShowModal && (
           <div
-            className="absolute top-0 -left-20 z-100 md:top-56 md:right-0 md:left-auto"
+            className="absolute top-0 -left-20 z-30 md:top-56 md:right-0 md:left-auto"
             ref={modalRef}
           >
             <NotificationModal


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
주영님이 구현해주신 **모달 컴포넌트**의 `z-index(40)`보다 **알림 모달**의 `z-index(100)`이 더 높게 설정되어, 
이상하게 보이는 문제를 수정하기 위해 **알림 모달**의 `z-index`를 낮췄습니다!
## 📝 상세 내용

Navbar 컴포넌트 내에서 **알림 모달의** `z-index`를 `100 -> 30`으로 조정했습니다.

## 🔗 관련 이슈

- #49 

## 🖼️ 스크린샷(선택사항)
### 수정 전
![image](https://github.com/user-attachments/assets/874d2ef7-bfb6-4ff2-bdc5-564602a8c036)

### 수정 후
![image](https://github.com/user-attachments/assets/4fd8157e-a814-4011-917a-045d210e9104)

## 💡 참고 사항