### PR TITLE
✨ feat: formatWorkTime함수에 잘못된 시간이 전달되었을 경우에 대한 예외 처리 추가

### DIFF
--- a/src/components/common/notification-modal/NotificationCard.tsx
+++ b/src/components/common/notification-modal/NotificationCard.tsx
@@ -9,7 +9,7 @@ interface NotificationCardProps {
   status: 'accepted' | 'rejected'; // 공고 지원 상태
   restaurantName: string; // 음식점 이름
   startsAt: string; // 공고 시작 시간 (ISO 8601 문자열)
-  workHour: number; // 근무 시간 (시간 단위)
+  workhour: number; // 근무 시간 (시간 단위)
   createdAt: string; // 알림 생성 시간 (ISO 8601 문자열)
 }
 
@@ -24,12 +24,12 @@ export default function NotificationCard({
   status,
   restaurantName,
   startsAt,
-  workHour,
+  workhour,
   createdAt,
 }: NotificationCardProps) {
   const formattedTime = formatWorkTime({
     startsAt,
-    workHour,
+    workhour,
   });
   const { role } = useContext(AuthContext);
   const formattedCreatedAt = calculateTimeDifference(createdAt);

--- a/src/components/common/notification-modal/NotificationModal.tsx
+++ b/src/components/common/notification-modal/NotificationModal.tsx
@@ -55,7 +55,7 @@ export default function NotificationModal({
               status={data.item.result}
               restaurantName={data.item.shop.item.name}
               startsAt={data.item.notice.item.startsAt}
-              workHour={data.item.notice.item.workhour}
+              workhour={data.item.notice.item.workhour}
               createdAt={data.item.createdAt}
             />
           ))}

--- a/src/utils/formatWorkTime.ts
+++ b/src/utils/formatWorkTime.ts
@@ -7,10 +7,10 @@ interface WorkTime {
 export default function formatWorkTime({
   startsAt,
   workHour,
-}: WorkTime): string {
+}: WorkTime): string | null {
   const date = new Date(startsAt);
   if (isNaN(date.getTime())) {
-    return '날짜 정보가 올바르지 않습니다';
+    return null;
   }
   const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
 

--- a/src/utils/formatWorkTime.ts
+++ b/src/utils/formatWorkTime.ts
@@ -9,7 +9,9 @@ export default function formatWorkTime({
   workHour,
 }: WorkTime): string {
   const date = new Date(startsAt);
-
+  if (isNaN(date.getTime())) {
+    return '날짜 정보가 올바르지 않습니다';
+  }
   const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
 
   /* 시각이 24시를 넘으면 다음날로 설정되어 자동으로 처리  */

--- a/src/utils/formatWorkTime.ts
+++ b/src/utils/formatWorkTime.ts
@@ -1,18 +1,17 @@
 interface WorkTime {
   startsAt: string | number; // 근무 시작 시간 (ISO 8601 형식 문자열)
-  workHour: number; // 근무 시간 (시간 단위)
+  workhour: number; // 근무 시간 (시간 단위)
 }
 
 /* 주어진 근무 시작 시간과 근무 시간을 기반으로 근무 시작~종료 시간을 "YYYY-MM-DD HH:mm~HH:mm" 형식의 문자열로 반환하는 함수  */
 export default function formatWorkTime({
   startsAt,
-  workHour,
+  workhour,
 }: WorkTime): string | null {
   const date = new Date(startsAt);
   if (isNaN(date.getTime())) {
     return null;
   }
-  const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
 
   /* 시각이 24시를 넘으면 다음날로 설정되어 자동으로 처리  */
   const endDate = new Date(date);

--- a/src/utils/formatWorkTime.ts
+++ b/src/utils/formatWorkTime.ts
@@ -15,14 +15,14 @@ export default function formatWorkTime({
   const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
 
   /* 시각이 24시를 넘으면 다음날로 설정되어 자동으로 처리  */
-  const endDate = new Date(kstDate);
-  endDate.setHours(endDate.getHours() + workHour);
+  const endDate = new Date(date);
+  endDate.setHours(endDate.getHours() + workhour);
 
-  const year = kstDate.getFullYear();
-  const month = String(kstDate.getMonth() + 1).padStart(2, '0');
-  const day = String(kstDate.getDate()).padStart(2, '0');
-  const startHours = String(kstDate.getHours()).padStart(2, '0');
-  const startMinutes = String(kstDate.getMinutes()).padStart(2, '0');
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const startHours = String(date.getHours()).padStart(2, '0');
+  const startMinutes = String(date.getMinutes()).padStart(2, '0');
 
   const endHours = String(endDate.getHours()).padStart(2, '0');
   const endMinutes = String(endDate.getMinutes()).padStart(2, '0');


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
-  근무 시작 시간과 근무 진행 시간을 입력하면 근무 시작 시간 ~ 근무 종료 시간을 `"YYYY-MM-DD HH:mm~HH:mm"` 형식의 문자열로 반환하는 함수 **formatWorkTime**에 대해 예외 처리를 추가했습니다.
- UTC를 KST로 변환하는 과정이 2번 반복되는 문제를 해결했습니다.
- prop 명을 변경했습니다.
## 📝 상세 내용

- **formatWorkTime** 함수에 잘못된 근무 시작 시간을 전달할 시에 'NaN-NaN-NaN NaN:NaN~NaN:NaN' 를 리턴하는 문제 발생
  이런 문제 상황을 함수 내에서 확인하도록 코드를 추가하여, 잘못된 근무 시작 시간이 전달되면 `null`를 리턴하도록 수정했습니다.
- Date()에서 자동으로 kst로 변환이 되므로 9시간을 더해주는 코드를 삭제했습니다.
- `workHour` prop을 api 응답 데이터에 맞게 `workhour`로 변경했습니다.


## 🔗 관련 이슈

- #50 

## 🖼️ 스크린샷(선택사항)
### 문제였던 부분
![image](https://github.com/user-attachments/assets/152657f5-8d32-4af3-b195-60b98ab025bb)

## 💡 참고 사항