### PR TITLE
✨ feat: 로그인 페이지 컴포넌트 구현 및 스타일링

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -45,7 +45,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = async (token: string, role: UserRole, userId: string) => {
     localStorage.setItem('accessToken', token);
-    localStorage.setItem('userRole', role);
+    localStorage.setItem('userRole', role || '');
     localStorage.setItem('userId', userId);
     setIsLoggedIn(true);
     setRole(role);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -45,13 +45,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = async (token: string, role: UserRole, userId: string) => {
     localStorage.setItem('accessToken', token);
-    localStorage.setItem('userRole', role || '');
+    localStorage.setItem('userRole', role);
+    localStorage.setItem('userId', userId);
     setIsLoggedIn(true);
     setRole(role);
     try {
       const alertRes = await getAlerts(userId);
       setAlarms(alertRes);
-      console.log('alertRes', alertRes);
     } catch (error) {
       console.error(error);
     }
@@ -60,6 +60,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('userRole');
+    localStorage.removeItem('userId');
     setIsLoggedIn(false);
     setRole(null);
     setAlarms(defaultAuthContext.alarms);

--- a/src/pages/account/Login.tsx
+++ b/src/pages/account/Login.tsx
@@ -62,7 +62,6 @@ export default function Login() {
     const { email, password } = values;
     try {
       const userInfo = await postToken({ email, password });
-      console.log('userInfo', userInfo);
       login(
         userInfo.item.token,
         userInfo.item.user.item.type,

--- a/src/pages/account/Login.tsx
+++ b/src/pages/account/Login.tsx
@@ -1,3 +1,126 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { postToken } from '@/api/userApi';
+import Input from '@/components/common/Input';
+import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import logo from '@/assets/images/logo.svg';
+
+interface LoginState {
+  email: string;
+  password: string;
+}
+
 export default function Login() {
-  return <div>로그인</div>;
+  const navigate = useNavigate();
+  const [values, setValues] = useState<LoginState>({
+    email: '',
+    password: '',
+  });
+  const [errorMessages, setErrorMessages] = useState({
+    emailError: '',
+    passwordError: '',
+  });
+  const [modal, setModal] = useState({
+    isOpen: false,
+    message: '',
+  });
+  const isFormValid =
+    values.email &&
+    values.password &&
+    !errorMessages.emailError &&
+    !errorMessages.passwordError;
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target;
+
+    setValues((prevValues) => ({
+      ...prevValues,
+      [name]: value,
+    }));
+
+    setErrorMessages((prevErrors) => {
+      const newErrors = { ...prevErrors };
+      if (name === 'email') {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        newErrors.emailError = emailRegex.test(value)
+          ? ''
+          : '이메일 형식으로 작성해 주세요.';
+      }
+      if (name === 'password') {
+        newErrors.passwordError =
+          value.length >= 8 ? '' : '8자 이상 입력해주세요.';
+      }
+      return newErrors;
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const { email, password } = values;
+    try {
+      const userInfo = await postToken({ email, password });
+      console.log('userInfo', userInfo);
+      navigate('/');
+    } catch (error) {
+      setModal({
+        isOpen: true,
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  const handleModalConfirm = () => {
+    setModal({ isOpen: false, message: '' });
+  };
+
+  return (
+    <>
+      <form
+        className="mx-auto flex min-h-screen flex-col items-center justify-center px-12 py-90"
+        onSubmit={handleSubmit}
+      >
+        <Link to="/" className="mb-40 h-45 w-full max-w-248">
+          <img src={logo} />
+        </Link>
+        <div className="flex w-full max-w-350 flex-col gap-28">
+          <Input
+            type="email"
+            name="email"
+            label="이메일"
+            error={errorMessages.emailError}
+            value={values.email}
+            onChange={handleChange}
+            required
+          />
+          <Input
+            type="password"
+            name="password"
+            label="비밀번호"
+            error={errorMessages.passwordError}
+            value={values.password}
+            onChange={handleChange}
+            required
+          />
+          <Button
+            type="submit"
+            disabled={!isFormValid}
+            className="w-full max-w-350"
+          >
+            로그인 하기
+          </Button>
+        </div>
+        <p className="mt-16">
+          회원이 아니신가요?{' '}
+          <Link to="/signup" className="text-[#5534DA] underline">
+            회원가입하기
+          </Link>
+        </p>
+      </form>
+
+      {modal.isOpen && (
+        <Modal onButtonClick={handleModalConfirm}>{modal.message}</Modal>
+      )}
+    </>
+  );
 }

--- a/src/pages/account/Login.tsx
+++ b/src/pages/account/Login.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { postToken } from '@/api/userApi';
+import { AuthContext } from '@/context/AuthContext';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import Modal from '@/components/common/Modal';
@@ -12,6 +13,7 @@ interface LoginState {
 }
 
 export default function Login() {
+  const { login } = useContext(AuthContext);
   const navigate = useNavigate();
   const [values, setValues] = useState<LoginState>({
     email: '',
@@ -61,6 +63,11 @@ export default function Login() {
     try {
       const userInfo = await postToken({ email, password });
       console.log('userInfo', userInfo);
+      login(
+        userInfo.item.token,
+        userInfo.item.user.item.type,
+        userInfo.item.user.item.id,
+      );
       navigate('/');
     } catch (error) {
       setModal({


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- 로그인 페이지 구현 (`/login`)
- 로그인 시 공고 리스트 페이지로 이동(`/`)
- 로그인 시에 로그인 정보 로컬스토리지에 저장

## 📝 상세 내용

- 로그인 페이지 구현
  - 주영님이 말씀주신 `checkvalidaty()` 를 사용해보려 했으나 회원가입 페이지와의 일관성을 유지하기 위해 기존 방식(state)로 진행하였습니다.
  - [x] 로고 버튼'을 클릭하면 공고 리스트 페이지로 이동하도록 하세요.
  - [x] '회원가입하기' 버튼을 클릭하면 회원가입 페이지로 이동하도록 하세요.
  - [x] 유효한 이메일과 비밀번호를 입력한 후 '로그인' 버튼을 클릭하면 공고 리스트 페이지로 이동하도록 하세요.
  - [x] 로그인 페이지에는 네비게이션바를 제외하세요.
  - [x] 비밀번호가 틀린 경우 “비밀번호가 일치하지 않습니다.”라는 경고 창을 보여주세요. 
      ->❗ **api 상 에러메시지가 "존재하지 않거나 비밀번호가 일치하지 않습니다" 라고 되어있는 관계로 해당 메시지로 구현됨**
  - [x] 이메일 input에서 focus out 시 이메일 형식이 아니라면 input에 빨간색 테두리를 표시하고 아래에 “이메일 형식으로 작성해 주세요.”라는 빨간색 에러 메시지를 표시하세요.
  - [x] 비밀번호 input에서 focus out 시 비밀번호가 8자 미만일 경우 빨간색 테두리와 “8자 이상 작성해 주세요.”라는 빨간색 에러 메시지를 표시하세요.
  - [x] 로그인에 성공하면 액세스 토큰이 발급되도록 하세요.
- 로그인 시에 accessToken, userRole, userId 가 로컬스토리지에 저장됨
- 로그인 시 알림 받아옴
## 🔗 관련 이슈

- #54 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

https://github.com/user-attachments/assets/349557f1-ce61-426c-9c0a-5e74797456c8


## 💡 참고 사항
- 리다이렉션 기능은 추후에 구현 예정입니다~!
- 현재는 로그인 시에만 알림을 받아오는데, 추후에 알림 읽기 기능 구현할 때 이에 대해 수정 예정입니다~!
- 다른 기능 구현하실 때 로컬 스토리지 내에 있는 토큰과 아이디 활용하시면 될것 같습니다.