### PR TITLE
✨ feat: application API 파일 생성 및 타입 정의

### DIFF
--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -38,3 +38,13 @@ export interface ApplicationNoticeInfo {
   item: ApplicationNoticeItem;
   link: LinkInfo[];
 }
+
+// GET /users/{user_id}/applications - 유저의 지원 목록 조회 response
+export interface ApplicationUserResponse {
+  offset: 'number';
+  limit: 'number';
+  count: 'number';
+  hasNext: 'boolean';
+  items: ApplicationUserInfo[];
+  link: LinkInfo[];
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -48,3 +48,13 @@ export interface ApplicationUserResponse {
   items: ApplicationUserInfo[];
   link: LinkInfo[];
 }
+
+// GET /shops/{shop_id}/notices/{notice_id}/applications - 가게의 특정 공고의 지원 목록 조회 response
+export interface ApplicationNoticeResponse {
+  offset: 'number';
+  limit: 'number';
+  count: 'number';
+  hasNext: 'boolean';
+  items: ApplicationNoticeInfo[];
+  link: LinkInfo[];
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -26,3 +26,8 @@ export interface ApplicationNoticeItem extends ApplicationUserItem {
     href: string;
   };
 }
+
+export interface ApplicationUserInfo {
+  item: ApplicationUserItem;
+  link: LinkInfo[];
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -4,3 +4,9 @@ export interface LinkInfo {
   method: string;
   href: string;
 }
+
+export interface ApplicationItem {
+  id: string;
+  status: 'pending' | 'accepted' | 'rejected' | 'canceled';
+  createdAt: string;
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -41,20 +41,20 @@ export interface ApplicationNoticeInfo {
 
 // GET /users/{user_id}/applications - 유저의 지원 목록 조회 response
 export interface ApplicationUserResponse {
-  offset: 'number';
-  limit: 'number';
-  count: 'number';
-  hasNext: 'boolean';
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
   items: ApplicationUserInfo[];
   link: LinkInfo[];
 }
 
 // GET /shops/{shop_id}/notices/{notice_id}/applications - 가게의 특정 공고의 지원 목록 조회 response
 export interface ApplicationNoticeResponse {
-  offset: 'number';
-  limit: 'number';
-  count: 'number';
-  hasNext: 'boolean';
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
   items: ApplicationNoticeInfo[];
   link: LinkInfo[];
 }

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -1,0 +1,6 @@
+export interface LinkInfo {
+  rel: string;
+  description: string;
+  method: string;
+  href: string;
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -31,3 +31,10 @@ export interface ApplicationUserInfo {
   item: ApplicationUserItem;
   link: LinkInfo[];
 }
+
+// POST /shops/{shop_id}/notices/{notice_id}/applications - 가게의 특정 공고 지원 등록 response
+// PUT /shops/{shop_id}/notices/{notice_id}/applications/{application_id} - 가게의 특정 공고 지원 승인, 거절 또는 취소 response
+export interface ApplicationNoticeInfo {
+  item: ApplicationNoticeItem;
+  link: LinkInfo[];
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -58,3 +58,8 @@ export interface ApplicationNoticeResponse {
   items: ApplicationNoticeInfo[];
   link: LinkInfo[];
 }
+
+// PUT /shops/{shop_id}/notices/{notice_id}/applications/{application_id} - 가게의 특정 공고 지원 승인, 거절 또는 취소 request
+export interface ApplicationRequest {
+  status: 'accepted' | 'rejected' | 'canceled';
+}

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -1,5 +1,6 @@
 import type { NoticeInfo } from './alertApi';
 import type { ShopInfo } from './shopApi';
+import type { UserProfileItem } from './userApi';
 
 export interface LinkInfo {
   rel: string;
@@ -17,4 +18,11 @@ export interface ApplicationItem {
 export interface ApplicationUserItem extends ApplicationItem {
   shop: ShopInfo;
   notice: NoticeInfo;
+}
+
+export interface ApplicationNoticeItem extends ApplicationUserItem {
+  user: {
+    item: UserProfileItem;
+    href: string;
+  };
 }

--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -1,3 +1,6 @@
+import type { NoticeInfo } from './alertApi';
+import type { ShopInfo } from './shopApi';
+
 export interface LinkInfo {
   rel: string;
   description: string;
@@ -9,4 +12,9 @@ export interface ApplicationItem {
   id: string;
   status: 'pending' | 'accepted' | 'rejected' | 'canceled';
   createdAt: string;
+}
+
+export interface ApplicationUserItem extends ApplicationItem {
+  shop: ShopInfo;
+  notice: NoticeInfo;
 }

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -1,3 +1,4 @@
+import type { ApplicationItem } from './applicationApi';
 import type { ShopInfo } from './shopApi';
 
 // Link (공통 링크 타입)
@@ -6,13 +7,6 @@ export interface LinkInfo {
   description: string;
   method: string;
   href: string;
-}
-
-// Application (신청 상태)
-export interface ApplicationItem {
-  id: string;
-  status: 'pending' | 'accepted' | 'rejected' | 'canceled';
-  createdAt: string;
 }
 
 // 공통 Notice Item


### PR DESCRIPTION
## 📌 변경 사항 개요

application API type들을 정의했습니다.

## 📝 상세 내용

## 🔗 관련 이슈

Resolves: #68 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항

- status에 `'pending' | 'accepted' | 'rejected' | 'canceled'` 과 `'accepted' | 'rejected' | 'canceled'` 2가지 union type 이 있는데 현재는 그냥 객체 안에 적었습니다만 별개로 분리하는 게 좋을지 의견 구해봅니다
- alert에서 사용하는 application은 형태가 조금 달라 `applicationApi` 파일에 넣지 않고 그대로 `alertApi` 파일에 남겼는데 분리해서 파일에 넣는게 좋을까요?