### PR TITLE
♻️ refactor: ApplicationStatus type 분리

### DIFF
--- a/src/api/applicationApi.ts
+++ b/src/api/applicationApi.ts
@@ -15,9 +15,15 @@ export interface LinkInfo {
   href: string;
 }
 
+export type ApplicationStatus =
+  | 'pending'
+  | 'accepted'
+  | 'rejected'
+  | 'canceled';
+
 export interface ApplicationItem {
   id: string;
-  status: 'pending' | 'accepted' | 'rejected' | 'canceled';
+  status: ApplicationStatus;
   createdAt: string;
 }
 
@@ -67,7 +73,7 @@ export interface ApplicationNoticeResponse {
 
 // PUT /shops/{shop_id}/notices/{notice_id}/applications/{application_id} - 가게의 특정 공고 지원 승인, 거절 또는 취소 request
 export interface ApplicationRequest {
-  status: 'accepted' | 'rejected' | 'canceled';
+  status: Exclude<ApplicationStatus, 'pending'>;
 }
 
 // GET /shops/{shop_id}/notices/{notice_id}/applications - 가게의 특정 공고의 지원 목록 조회


### PR DESCRIPTION
## 📌 변경 사항 개요

ApplicationStatus type(`'pending'  | 'accepted'  | 'rejected'  | 'canceled'`) 분리

## 📝 상세 내용

- `'pending'  | 'accepted'  | 'rejected'  | 'canceled'` 이 외부에서 쓰이는 데가 있어 오타 및 오류 방지로 type을 분리하였습니다.

## 🔗 관련 이슈

Resolves: #108 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항

- `Exclude<ApplicationStatus, 'pending'>`(`'accepted'  | 'rejected'  | 'canceled'`) type도 분리할까 하다가 따로 분리는 안했습니다. 분리가 필요한 거 같다 하시면 의견 부탁드립니다~