### PR TITLE
✨ feat: 내 프로필 수정 페이지 구현

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -13,6 +13,7 @@ interface DropdownProps {
   setSelect: Dispatch<SetStateAction<string>>; // Dispatch<SetStateAction<string>>는 set함수 타입
   placeholder?: string;
   variant: 'form' | 'filter';
+  id?: string;
 }
 
 export default function Dropdown({
@@ -21,6 +22,7 @@ export default function Dropdown({
   setSelect,
   placeholder = '선택',
   variant,
+  id,
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -54,6 +56,7 @@ export default function Dropdown({
   return (
     <div ref={dropdownRef} className="relative">
       <button
+        id={id}
         type="button"
         onClick={toggleDropdown}
         className={`flex items-center justify-between rounded-md ${variant === 'form' ? 'h-58 w-full border border-gray-30 bg-white px-20 py-16 text-body1 font-regular' : 'h-30 w-105 justify-center gap-6 rounded-[5px] bg-gray-10 px-12 text-body2 font-bold'}`}

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -1,3 +1,8 @@
+import { Link } from 'react-router-dom';
 export default function Profile() {
-  return <div>내 프로필 상세 (알바님)</div>;
+  return (
+    <>
+      <Link to="/profile/edit">등록하기</Link>
+    </>
+  );
 }

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -7,31 +7,36 @@ import { ADDRESS_OPTIONS } from '@/constants/dropdownOptions';
 
 export default function ProfileForm() {
   return (
-    <form className="mx-12 mt-40 mb-80 flex flex-col gap-24">
-      <div className="flex items-center justify-between">
-        <h1 className="text-h3 font-bold">내 프로필</h1>
-        <Link to="/profile">
-          <img src={close} alt="닫기" />
-        </Link>
-      </div>
-      <div className="flex flex-col gap-20">
-        <Input label="이름*" />
-        <Input label="연락처*" />
-        <div className="flex flex-col gap-8 text-body1/26 font-regular">
-          <label htmlFor="region">선호 지역</label>
-          <Dropdown id="region" variant="form" options={ADDRESS_OPTIONS} />
+    <div className="min-h-screen bg-gray-5">
+      <form className="mx-12 flex flex-col gap-24 pt-40 pb-80 md:mx-32 md:gap-32 md:py-60 lg:mx-auto lg:w-964">
+        <div className="flex items-center justify-between">
+          <h1 className="text-h3 font-bold md:text-h1">내 프로필</h1>
+          <Link to="/profile">
+            <img src={close} alt="닫기" className="md:size-32" />
+          </Link>
         </div>
-        <div className="flex flex-col gap-8 text-body1/26 font-regular">
-          <label htmlFor="bio">소개</label>
-          <textarea
-            name="bio"
-            id="bio"
-            className="h-153 resize-none rounded-[5px] border border-gray-30 px-20 py-16"
-            placeholder="입력"
-          ></textarea>
+        <div className="flex flex-col gap-20 md:gap-24">
+          <div className="grid grid-cols-1 gap-20 md:grid-cols-2 md:gap-y-24 lg:grid-cols-3">
+            <Input label="이름*" />
+            <Input label="연락처*" />
+            <div className="flex flex-col gap-8 text-body1/26 font-regular">
+              <label htmlFor="region">선호 지역</label>
+              <Dropdown id="region" variant="form" options={ADDRESS_OPTIONS} />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-8 text-body1/26 font-regular">
+            <label htmlFor="bio">소개</label>
+            <textarea
+              name="bio"
+              id="bio"
+              className="h-153 resize-none rounded-[5px] border border-gray-30 bg-white px-20 py-16 placeholder-gray-40"
+              placeholder="입력"
+            ></textarea>
+          </div>
         </div>
-      </div>
-      <Button>등록하기</Button>
-    </form>
+        <Button className="md:mx-auto md:w-312">등록하기</Button>
+      </form>
+    </div>
   );
 }

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -10,14 +10,19 @@ import { ADDRESS_OPTIONS } from '@/constants/dropdownOptions';
 
 export default function ProfileForm() {
   const navigate = useNavigate();
+
+  // 사용자 입력값 상태 (이름, 전화번호, 소개글)
   const [profileInfo, setProfileInfo] = useState({
     name: '',
     phone: '',
     bio: '',
   });
+
+  // dropdown 컴포넌트에 set함수를 전달하기 위해 address는 따로 분리
   const [selectedAddress, setSelectedAddress] = useState<SeoulDistrict | ''>(
     '',
-  ); // dropdown 컴포넌트에 set함수를 전달하기 위해 address는 따로 분리
+  );
+
   const [modal, setModal] = useState({
     isOpen: false,
     message: '',
@@ -25,6 +30,7 @@ export default function ProfileForm() {
   const userId = localStorage.getItem('userId');
 
   useEffect(() => {
+    // 로그인이 안된 상태에 대한 처리
     if (!userId) {
       setModal({
         isOpen: true,
@@ -56,7 +62,7 @@ export default function ProfileForm() {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) {
     const { name, value } = e.target;
-    const sanitized = name === 'phone' ? value.replace(/[^0-9]/g, '') : value; // phone은 숫자만
+    const sanitized = name === 'phone' ? value.replace(/[^0-9]/g, '') : value; // phone은 숫자만 입력 가능하도록 설정
 
     setProfileInfo((prev) => ({
       ...prev,
@@ -68,6 +74,7 @@ export default function ProfileForm() {
     e.preventDefault();
     const { name, phone, bio } = profileInfo;
 
+    // 로그인이 안된 상태에 대한 처리
     if (!userId) {
       setModal({
         isOpen: true,
@@ -76,6 +83,7 @@ export default function ProfileForm() {
       return;
     }
 
+    // 이름이 입력되지 않은 경우
     if (!name.trim()) {
       setModal({
         isOpen: true,
@@ -84,6 +92,7 @@ export default function ProfileForm() {
       return;
     }
 
+    // 지역이 선택되지 않은 경우
     if (!selectedAddress) {
       setModal({
         isOpen: true,

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -24,6 +24,13 @@ export default function ProfileForm() {
   const userId = localStorage.getItem('userId');
 
   useEffect(() => {
+    if (!userId) {
+      setModal({
+        isOpen: true,
+        message: '로그인 먼저 해주세요.',
+      });
+      return;
+    }
     const fetchUserInfo = async () => {
       try {
         const userInfo = await getUser(userId);
@@ -41,7 +48,9 @@ export default function ProfileForm() {
     fetchUserInfo();
   }, [userId]);
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
     const { name, value } = e.target;
     const sanitized = name === 'phone' ? value.replace(/[^0-9]/g, '') : value; // phone은 숫자만
 
@@ -51,7 +60,7 @@ export default function ProfileForm() {
     }));
   }
 
-  function handleSelect(value) {
+  function handleSelect(value: string) {
     setProfileInfo((prev) => ({
       ...prev,
       address: value,
@@ -62,10 +71,10 @@ export default function ProfileForm() {
     e.preventDefault();
     const { name, phone, address, bio } = profileInfo;
 
-    if (name === '') {
+    if (!userId) {
       setModal({
         isOpen: true,
-        message: '이름을 입력해주세요.',
+        message: '로그인 먼저 해주세요.',
       });
       return;
     }
@@ -98,6 +107,9 @@ export default function ProfileForm() {
     if (modal.message === '등록이 완료되었습니다.') {
       setModal({ isOpen: false, message: '' });
       navigate('/profile');
+    } else if (modal.message === '로그인 먼저 해주세요.') {
+      setModal({ isOpen: false, message: '' });
+      navigate('/login');
     } else {
       setModal({ isOpen: false, message: '' });
     }
@@ -155,7 +167,7 @@ export default function ProfileForm() {
             ></textarea>
           </div>
         </div>
-        <Button onClick={handleSubmit} className="md:mx-auto md:w-312">
+        <Button type="submit" className="md:mx-auto md:w-312">
           등록하기
         </Button>
       </form>

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -1,14 +1,114 @@
-import { Link } from 'react-router-dom';
+import { useState, useEffect, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { getUser, putUser } from '@/api/userApi';
 import Dropdown from '@/components/common/Dropdown';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
 import close from '@/assets/icons/close.svg';
 import { ADDRESS_OPTIONS } from '@/constants/dropdownOptions';
 
 export default function ProfileForm() {
+  const navigate = useNavigate();
+  const [profileInfo, setProfileInfo] = useState({
+    name: '',
+    phone: '',
+    address: '',
+    bio: '',
+  });
+
+  const [modal, setModal] = useState({
+    isOpen: false,
+    message: '',
+  });
+  const userId = localStorage.getItem('userId');
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const userInfo = await getUser(userId);
+        setProfileInfo({
+          name: userInfo.item.name ?? '',
+          phone: userInfo.item.phone ?? '',
+          address: userInfo.item.address ?? '',
+          bio: userInfo.item.bio ?? '',
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchUserInfo();
+  }, [userId]);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target;
+    const sanitized = name === 'phone' ? value.replace(/[^0-9]/g, '') : value; // phone은 숫자만
+
+    setProfileInfo((prev) => ({
+      ...prev,
+      [name]: sanitized,
+    }));
+  }
+
+  function handleSelect(value) {
+    setProfileInfo((prev) => ({
+      ...prev,
+      address: value,
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const { name, phone, address, bio } = profileInfo;
+
+    if (name === '') {
+      setModal({
+        isOpen: true,
+        message: '이름을 입력해주세요.',
+      });
+      return;
+    }
+
+    try {
+      await putUser(userId, {
+        name,
+        phone,
+        address,
+        bio,
+      });
+      setModal({
+        isOpen: true,
+        message: '등록이 완료되었습니다.',
+      });
+    } catch (error) {
+      const rawMessage = (error as Error).message;
+      const friendlyMessage = rawMessage.includes('시군구')
+        ? '선호 지역을 선택해주세요.'
+        : rawMessage;
+
+      setModal({
+        isOpen: true,
+        message: friendlyMessage,
+      });
+    }
+  }
+
+  const handleModalConfirm = useCallback(() => {
+    if (modal.message === '등록이 완료되었습니다.') {
+      setModal({ isOpen: false, message: '' });
+      navigate('/profile');
+    } else {
+      setModal({ isOpen: false, message: '' });
+    }
+  }, [modal.message, navigate]);
+
   return (
     <div className="min-h-screen bg-gray-5">
-      <form className="mx-12 flex flex-col gap-24 pt-40 pb-80 md:mx-32 md:gap-32 md:py-60 lg:mx-auto lg:w-964">
+      <form
+        className="mx-12 flex flex-col gap-24 pt-40 pb-80 md:mx-32 md:gap-32 md:py-60 lg:mx-auto lg:w-964"
+        onSubmit={handleSubmit}
+      >
         <div className="flex items-center justify-between">
           <h1 className="text-h3 font-bold md:text-h1">내 프로필</h1>
           <Link to="/profile">
@@ -17,11 +117,29 @@ export default function ProfileForm() {
         </div>
         <div className="flex flex-col gap-20 md:gap-24">
           <div className="grid grid-cols-1 gap-20 md:grid-cols-2 md:gap-y-24 lg:grid-cols-3">
-            <Input label="이름*" />
-            <Input label="연락처*" />
+            <Input
+              label="이름*"
+              name="name"
+              value={profileInfo.name}
+              onChange={handleChange}
+            />
+            <Input
+              label="연락처*"
+              type="tel"
+              name="phone"
+              maxLength={11}
+              value={profileInfo.phone}
+              onChange={handleChange}
+            />
             <div className="flex flex-col gap-8 text-body1/26 font-regular">
-              <label htmlFor="region">선호 지역</label>
-              <Dropdown id="region" variant="form" options={ADDRESS_OPTIONS} />
+              <label htmlFor="region">선호 지역*</label>
+              <Dropdown
+                id="region"
+                variant="form"
+                options={ADDRESS_OPTIONS}
+                selected={profileInfo.address}
+                setSelect={handleSelect}
+              />
             </div>
           </div>
 
@@ -32,11 +150,20 @@ export default function ProfileForm() {
               id="bio"
               className="h-153 resize-none rounded-[5px] border border-gray-30 bg-white px-20 py-16 placeholder-gray-40"
               placeholder="입력"
+              value={profileInfo.bio}
+              onChange={handleChange}
             ></textarea>
           </div>
         </div>
-        <Button className="md:mx-auto md:w-312">등록하기</Button>
+        <Button onClick={handleSubmit} className="md:mx-auto md:w-312">
+          등록하기
+        </Button>
       </form>
+      {modal.isOpen && (
+        <Modal onClose={handleModalConfirm} onButtonClick={handleModalConfirm}>
+          {modal.message}
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -73,6 +73,22 @@ export default function ProfileForm() {
       return;
     }
 
+    if (!name.trim()) {
+      setModal({
+        isOpen: true,
+        message: '이름을 입력해주세요.',
+      });
+      return;
+    }
+
+    if (!selectedAddress) {
+      setModal({
+        isOpen: true,
+        message: '선호 지역을 선택해주세요',
+      });
+      return;
+    }
+
     try {
       await putUser(userId, {
         name,

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { getUser, putUser } from '@/api/userApi';
+import { getUser, putUser, type SeoulDistrict } from '@/api/userApi';
 import Dropdown from '@/components/common/Dropdown';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
@@ -13,10 +13,11 @@ export default function ProfileForm() {
   const [profileInfo, setProfileInfo] = useState({
     name: '',
     phone: '',
-    address: '',
     bio: '',
   });
-
+  const [selectedAddress, setSelectedAddress] = useState<SeoulDistrict | ''>(
+    '',
+  ); // dropdown 컴포넌트에 set함수를 전달하기 위해 address는 따로 분리
   const [modal, setModal] = useState({
     isOpen: false,
     message: '',
@@ -37,9 +38,9 @@ export default function ProfileForm() {
         setProfileInfo({
           name: userInfo.item.name ?? '',
           phone: userInfo.item.phone ?? '',
-          address: userInfo.item.address ?? '',
           bio: userInfo.item.bio ?? '',
         });
+        setSelectedAddress((userInfo.item.address as SeoulDistrict) ?? '');
       } catch (error) {
         console.error(error);
       }
@@ -60,16 +61,9 @@ export default function ProfileForm() {
     }));
   }
 
-  function handleSelect(value: string) {
-    setProfileInfo((prev) => ({
-      ...prev,
-      address: value,
-    }));
-  }
-
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const { name, phone, address, bio } = profileInfo;
+    const { name, phone, bio } = profileInfo;
 
     if (!userId) {
       setModal({
@@ -83,7 +77,7 @@ export default function ProfileForm() {
       await putUser(userId, {
         name,
         phone,
-        address,
+        address: selectedAddress,
         bio,
       });
       setModal({
@@ -91,14 +85,9 @@ export default function ProfileForm() {
         message: '등록이 완료되었습니다.',
       });
     } catch (error) {
-      const rawMessage = (error as Error).message;
-      const friendlyMessage = rawMessage.includes('시군구')
-        ? '선호 지역을 선택해주세요.'
-        : rawMessage;
-
       setModal({
         isOpen: true,
-        message: friendlyMessage,
+        message: (error as Error).message,
       });
     }
   }
@@ -149,8 +138,8 @@ export default function ProfileForm() {
                 id="region"
                 variant="form"
                 options={ADDRESS_OPTIONS}
-                selected={profileInfo.address}
-                setSelect={handleSelect}
+                selected={selectedAddress}
+                setSelect={setSelectedAddress}
               />
             </div>
           </div>

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -1,3 +1,37 @@
+import { Link } from 'react-router-dom';
+import Dropdown from '@/components/common/Dropdown';
+import Input from '@/components/common/Input';
+import Button from '@/components/common/Button';
+import close from '@/assets/icons/close.svg';
+import { ADDRESS_OPTIONS } from '@/constants/dropdownOptions';
+
 export default function ProfileForm() {
-  return <div>내 프로필 등록/편집 (알바님)</div>;
+  return (
+    <form className="mx-12 mt-40 mb-80 flex flex-col gap-24">
+      <div className="flex items-center justify-between">
+        <h1 className="text-h3 font-bold">내 프로필</h1>
+        <Link to="/profile">
+          <img src={close} alt="닫기" />
+        </Link>
+      </div>
+      <div className="flex flex-col gap-20">
+        <Input label="이름*" />
+        <Input label="연락처*" />
+        <div className="flex flex-col gap-8 text-body1/26 font-regular">
+          <label htmlFor="region">선호 지역</label>
+          <Dropdown id="region" variant="form" options={ADDRESS_OPTIONS} />
+        </div>
+        <div className="flex flex-col gap-8 text-body1/26 font-regular">
+          <label htmlFor="bio">소개</label>
+          <textarea
+            name="bio"
+            id="bio"
+            className="h-153 resize-none rounded-[5px] border border-gray-30 px-20 py-16"
+            placeholder="입력"
+          ></textarea>
+        </div>
+      </div>
+      <Button>등록하기</Button>
+    </form>
+  );
 }

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -42,7 +42,10 @@ export default function ProfileForm() {
         });
         setSelectedAddress((userInfo.item.address as SeoulDistrict) ?? '');
       } catch (error) {
-        console.error(error);
+        setModal({
+          isOpen: true,
+          message: (error as Error).message,
+        });
       }
     };
 


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- 내 프로필 수정 페이지(`/profile/edit`)을 구현했습니다.
- 드롭다운 컴포넌트의 props로 id를 추가했습니다.
- 테스트를 위해 프로필 페이지에 링크를 추가했습니다.(`/profile`)

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
### 사용자 정보 관리
```tsx
// 사용자 입력값 상태 (이름, 전화번호, 소개글)
  const [profileInfo, setProfileInfo] = useState({
    name: '',
    phone: '',
    bio: '',
  });

  // dropdown 컴포넌트에 set함수를 전달하기 위해 address는 따로 분리
  const [selectedAddress, setSelectedAddress] = useState<SeoulDistrict | ''>(
    '',
  );
```
api 요청에 필요한 값들을 state로 관리합니다. 다만, dropdown의 setSelect로 전달할 요소가 set함수로 정해져있어, address는 다른 state로 따로 분리하였습니다.

### 예외 상황 처리
- 로그인이 안된 경우
  ```tsx
  if (!isLoggedIn || !userId) {
    setModal({
      isOpen: true,
      message: '로그인 먼저 해주세요.',
    });
    return;
  }
  ```
  '로그인 먼저 해주세요.'라는 모달을 보여준 뒤에 로그인 페이지로 이동시킵니다.

- 이름이 입력되지 않은 경우
  ```tsx
    if (!name.trim()) {
      setModal({
        isOpen: true,
        message: '이름을 입력해주세요.',
      });
      return;
    }
  ```
'이름을 입력해주세요.'라는 모달을 보여줍니다.

- 선호 지역이 선택되지 않은 경우 (figma에는 선호 지역에 *이 없어서, 필수가 아닌줄 알았으나, 선택하지 않으면 api상에서 에러가 발생합니다. 따라서 따로 처리하였으며 *도 포함시켰습니다.)
  ```tsx
    if (!selectedAddress) {
      setModal({
        isOpen: true,
        message: '선호 지역을 선택해주세요',
      });
      return;
    }
  ```
'선호 지역을 선택해주세요'라는 모달을 보여줍니다.

### 모달 관련
```tsx
  const handleModalConfirm = useCallback(() => {
    if (modal.message === '등록이 완료되었습니다.') {
      setModal({ isOpen: false, message: '' });
      navigate('/profile');
    } else if (modal.message.includes('로그인')) {
      setModal({ isOpen: false, message: '' });
      navigate('/login');
    } else {
      setModal({ isOpen: false, message: '' });
    }
  }, [modal.message, navigate]);
```
성공적으로 등록 시에는 `/profile` 로 이동하며, 로그인이 안된 경우에는 `/login`로 이동합니다.

### 드롭다운 컴포넌트에 id속성 추가
페이지 내에서 label과 드롭다운을 연결시키기 위해 id속성을 추가하였습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #98 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
### 프로필 등록/수정 기능 및 로그아웃 시 처리

https://github.com/user-attachments/assets/dad92861-630b-4979-b839-c0436fbf212c

### 반응형 페이지 구현

https://github.com/user-attachments/assets/9b3826be-ebe6-4715-a3ac-3a7954c97c03


## 💡 참고 사항
- 로그인이 안된 상태에서 프로필 수정 페이지에 접근하면 경고 모달을 띄우고 로그인 페이지로 이동시키는 기능은 구현하였지만, 현재 **알바님**만 내 프로필 페이지가 존재하며 **사장님**은 내 프로필 페이지가 존재하지 않기 때문에, 해당 접근을 막는 것에 대한 처리도 구현해야 할 것 같습니다. 추후에 내 프로필 상세 페이지까지 구현이 되면 구현 해보겠습니다.
- 앞에도 말씀드렸듯이, 피그마 상에서는 선호 지역에 `*`이 없어 필수 선택이 아닌 것 처럼 나와있지만 선택하지 않을 시에 api에서 에러를 반환하기 때문에 이에 대한 예외 처리와, 선호 지역에 `*`를 붙여 **필수 입력**이라는 걸 표시했습니다.
- 현재 **로컬스토리지**에서 `accesstoken`, `userId`, `userRole`를 관리하고 있는데, 생각해보니 **AuthContext**에서 `userId`와 `userRole`을 저장하고, **로컬스토리지**에서는 `accesstoken`만 관리하는 게 더 나을 것 같다는 생각이 들었습니다! 작업하시는 분들 계실까봐 수정하진 않고 그냥 생각만 해봤는데 이에 대한 의견 말씀해주시면 감사하겠습니다🙏🙏