### PR TITLE
✨ feat: notice API 함수 구현 및 type 리팩토링

### DIFF
--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -26,12 +26,12 @@ export interface NoticeItem {
 }
 
 // shop 포함된 확장형 Notice (리스트, 등록, 수정에 사용)
-export interface NoticeWithShopItem extends NoticeItem {
+export interface NoticeShopItem extends NoticeItem {
   shop: ShopInfo;
 }
 
 // application까지 포함된 상세형 Notice (상세 조회 시 사용)
-export interface NoticeDetailItem extends NoticeWithShopItem {
+export interface NoticeDetailItem extends NoticeShopItem {
   currentUserApplication?: {
     item: ApplicationItem;
   };
@@ -45,7 +45,7 @@ export interface NoticeInfo {
 // POST /shops/{shop_id}/notices 공고 등록 - Response
 // PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정 - Response
 export interface NoticeUpsertResponse {
-  item: NoticeWithShopItem;
+  item: NoticeShopItem;
   links: LinkInfo[];
 }
 

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -1,3 +1,5 @@
+import api from './api';
+import { AxiosError } from 'axios';
 import type { ApplicationItem } from './applicationApi';
 import type { ShopInfo } from './shopApi';
 
@@ -84,3 +86,32 @@ export interface NoticeUpsertRequest {
   workhour: number;
   description: string;
 }
+
+// GET /notices 공고 조회
+export const getNotices = async (query?: {
+  offset?: number;
+  limit?: number;
+  address?: string;
+  keyword?: string;
+  startsAtGte?: string;
+  hourlyPayGte?: number;
+  sort?: 'time' | 'pay' | 'hour' | 'shop';
+}): Promise<GetNoticesResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      ...query,
+      offset: String(query?.offset ?? ''),
+      limit: String(query?.limit ?? ''),
+      hourlyPayGte: String(query?.hourlyPayGte ?? ''),
+    });
+    const response = await api.get<GetNoticesResponse>(`/notices?${newQuery}`);
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -182,3 +182,25 @@ export const getShopNotice = async (
     }
   }
 };
+
+// PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정
+export const putShopNotice = async (
+  shopId: string,
+  noticeId: string,
+  body: NoticeUpsertRequest,
+): Promise<NoticeUpsertResponse> => {
+  try {
+    const response = await api.put<NoticeUpsertResponse>(
+      `/shops/${shopId}/notices/${noticeId}`,
+      body,
+    );
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -37,6 +37,11 @@ export interface NoticeDetailItem extends NoticeWithShopItem {
   };
 }
 
+export interface NoticeInfo {
+  item: NoticeItem;
+  links: LinkInfo[];
+}
+
 // GET /notices 공고 조회 - Response
 export interface GetNoticesResponse {
   offset: number;

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -50,10 +50,7 @@ export interface GetNoticesResponse {
   hasNext: boolean;
   address: string[];
   keyword?: string;
-  items: {
-    item: NoticeWithShopItem;
-    links: LinkInfo[];
-  }[];
+  items: NoticeUpsertResponse[];
   links: LinkInfo[];
 }
 

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -63,10 +63,7 @@ export interface GetShopNoticesResponse {
   limit: number;
   count: number;
   hasNext: boolean;
-  items: {
-    item: NoticeItem;
-    links: LinkInfo[];
-  }[];
+  items: NoticeInfo[];
   links: LinkInfo[];
 }
 

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -42,6 +42,19 @@ export interface NoticeInfo {
   links: LinkInfo[];
 }
 
+// POST /shops/{shop_id}/notices 공고 등록 - Response
+// PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정 - Response
+export interface NoticeUpsertResponse {
+  item: NoticeWithShopItem;
+  links: LinkInfo[];
+}
+
+// GET /shops/{shop_id}/notices/{notice_id} 가게의 특정 공고 조회 - Response
+export interface GetNoticeDetailResponse {
+  item: NoticeDetailItem;
+  links: LinkInfo[];
+}
+
 // GET /notices 공고 조회 - Response
 export interface GetNoticesResponse {
   offset: number;
@@ -61,19 +74,6 @@ export interface GetShopNoticesResponse {
   count: number;
   hasNext: boolean;
   items: NoticeInfo[];
-  links: LinkInfo[];
-}
-
-// POST /shops/{shop_id}/notices 공고 등록 - Response
-// PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정 - Response
-export interface NoticeUpsertResponse {
-  item: NoticeWithShopItem;
-  links: LinkInfo[];
-}
-
-// GET /shops/{shop_id}/notices/{notice_id} 가게의 특정 공고 조회 - Response
-export interface GetNoticeDetailResponse {
-  item: NoticeDetailItem;
   links: LinkInfo[];
 }
 

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -117,3 +117,27 @@ export const getNotices = async (query?: {
     }
   }
 };
+
+// GET /shops/{shop_id}/notices 가게별 공고 조회
+export const getShopNotices = async (
+  shopId: string,
+  query?: { offset?: number; limit?: number },
+): Promise<GetShopNoticesResponse> => {
+  try {
+    const newQuery = new URLSearchParams({
+      offset: String(query?.offset ?? ''),
+      limit: String(query?.limit ?? ''),
+    });
+    const response = await api.get<GetShopNoticesResponse>(
+      `/shops/${shopId}/notices?${newQuery}`,
+    );
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -1,6 +1,10 @@
 import type { ApplicationItem } from './applicationApi';
 import type { ShopInfo } from './shopApi';
 
+interface ErrorMessage {
+  message: string;
+}
+
 // Link (공통 링크 타입)
 export interface LinkInfo {
   rel: string;

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -50,7 +50,7 @@ export interface NoticeShopInfo {
 }
 
 // GET /shops/{shop_id}/notices/{notice_id} 가게의 특정 공고 조회 - Response
-export interface GetNoticeDetailResponse {
+export interface NoticeDetailInfo {
   item: NoticeDetailItem;
   links: LinkInfo[];
 }
@@ -164,9 +164,9 @@ export const postShopNotice = async (
 export const getShopNotice = async (
   shopId: string,
   noticeId: string,
-): Promise<GetNoticeDetailResponse> => {
+): Promise<NoticeDetailInfo> => {
   try {
-    const response = await api.get<GetNoticeDetailResponse>(
+    const response = await api.get<NoticeDetailInfo>(
       `/shops/${shopId}/notices/${noticeId}`,
     );
     return response.data;

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -44,7 +44,7 @@ export interface NoticeInfo {
 
 // POST /shops/{shop_id}/notices 공고 등록 - Response
 // PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정 - Response
-export interface NoticeUpsertResponse {
+export interface NoticeShopInfo {
   item: NoticeShopItem;
   links: LinkInfo[];
 }
@@ -63,7 +63,7 @@ export interface GetNoticesResponse {
   hasNext: boolean;
   address: string[];
   keyword?: string;
-  items: NoticeUpsertResponse[];
+  items: NoticeShopInfo[];
   links: LinkInfo[];
 }
 
@@ -143,9 +143,9 @@ export const getShopNotices = async (
 export const postShopNotice = async (
   shopId: string,
   body: NoticeUpsertRequest,
-): Promise<NoticeUpsertResponse> => {
+): Promise<NoticeShopInfo> => {
   try {
-    const response = await api.post<NoticeUpsertResponse>(
+    const response = await api.post<NoticeShopInfo>(
       `/shops/${shopId}/notices`,
       body,
     );
@@ -185,9 +185,9 @@ export const putShopNotice = async (
   shopId: string,
   noticeId: string,
   body: NoticeUpsertRequest,
-): Promise<NoticeUpsertResponse> => {
+): Promise<NoticeShopInfo> => {
   try {
-    const response = await api.put<NoticeUpsertResponse>(
+    const response = await api.put<NoticeShopInfo>(
       `/shops/${shopId}/notices/${noticeId}`,
       body,
     );

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -162,3 +162,23 @@ export const postShopNotice = async (
     }
   }
 };
+
+// GET /shops/{shop_id}/notices/{notice_id} 가게의 특정 공고 조회
+export const getShopNotice = async (
+  shopId: string,
+  noticeId: string,
+): Promise<GetNoticeDetailResponse> => {
+  try {
+    const response = await api.get<GetNoticeDetailResponse>(
+      `/shops/${shopId}/notices/${noticeId}`,
+    );
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -141,3 +141,24 @@ export const getShopNotices = async (
     }
   }
 };
+
+// POST /shops/{shop_id}/notices 공고 등록
+export const postShopNotice = async (
+  shopId: string,
+  body: NoticeUpsertRequest,
+): Promise<NoticeUpsertResponse> => {
+  try {
+    const response = await api.post<NoticeUpsertResponse>(
+      `/shops/${shopId}/notices`,
+      body,
+    );
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorMessage>; // 에러 타입 명시
+    if (axiosError.response) {
+      throw new Error(axiosError.response.data.message);
+    } else {
+      throw new Error('서버에 연결할 수 없습니다. 인터넷 연결을 확인해주세요.');
+    }
+  }
+};

--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -31,8 +31,7 @@ export interface NoticeDetailItem extends NoticeWithShopItem {
   };
 }
 
-// GET /notices 공고 조회
-// Response
+// GET /notices 공고 조회 - Response
 export interface GetNoticesResponse {
   offset: number;
   limit: number;
@@ -47,8 +46,7 @@ export interface GetNoticesResponse {
   links: LinkInfo[];
 }
 
-// GET /shops/{shop_id}/notices 가게별 공고 조회
-// Response
+// GET /shops/{shop_id}/notices 가게별 공고 조회 - Response
 export interface GetShopNoticesResponse {
   offset: number;
   limit: number;
@@ -61,25 +59,24 @@ export interface GetShopNoticesResponse {
   links: LinkInfo[];
 }
 
-// POST /shops/{shop_id}/notices 공고 등록
-// PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정
-// Request Body
-export interface NoticeUpsertRequest {
-  hourlyPay: number;
-  startsAt: string;
-  workhour: number;
-  description: string;
-}
-
-// Response
+// POST /shops/{shop_id}/notices 공고 등록 - Response
+// PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정 - Response
 export interface NoticeUpsertResponse {
   item: NoticeWithShopItem;
   links: LinkInfo[];
 }
 
-// GET /shops/{shop_id}/notices/{notice_id} 가게의 특정 공고 조회
-// Response
+// GET /shops/{shop_id}/notices/{notice_id} 가게의 특정 공고 조회 - Response
 export interface GetNoticeDetailResponse {
   item: NoticeDetailItem;
   links: LinkInfo[];
+}
+
+// POST /shops/{shop_id}/notices 공고 등록 - Request Body
+// PUT /shops/{shop_id}/notices/{notice_id} 특정 공고 수정 - Request Body
+export interface NoticeUpsertRequest {
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
 }

--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -9,7 +9,7 @@ import ArrowUpRed40 from '@/assets/icons/arrow-up-red40.svg';
 import ArrowUpRed30 from '@/assets/icons/arrow-up-red30.svg';
 import ArrowUpRed20 from '@/assets/icons/arrow-up-red20.svg';
 import PostImg from '@/assets/images/post-default.png';
-import type { NoticeWithShopItem } from '@/api/noticeApi';
+import type { NoticeShopItem } from '@/api/noticeApi';
 
 // 상태 계산
 function getStatus(
@@ -24,7 +24,7 @@ function getStatus(
   return 'ACTIVE';
 }
 
-export default function Post({ data }: { data: NoticeWithShopItem }) {
+export default function Post({ data }: { data: NoticeShopItem }) {
   const {
     hourlyPay,
     workhour,


### PR DESCRIPTION
## 📌 변경 사항 개요

- notice API 함수들을 구현했습니다.
- `noticeApi` 파일의 type들을 리팩토링하였습니다.

## 📝 상세 내용

- `getNotices` : GET `/notices` 함수
- `getShopNotices` : GET `/shops/{shop_id}/notices` 함수
- `postShopNotice` : POST `/shops/{shop_id}/notices` 함수
- `getShopNotice`  : GET `/shops/{shop_id}/notices/{notice_id}` 함수
- `putShopNotice` : PUT `/shops/{shop_id}/notices/{notice_id}` 함수

## 🔗 관련 이슈

Resolves: #76 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항

- Shop 이 붙은 API 함수들의 이름에서 Shop을 빼고 `getNotices` > `getTotalNotices` 이런 식으로 바꿀까 생각도 했는데 일단은 최대한 api url과 비슷하게 두었습니다.
- `putShopNotice`의 마감된 공고는 수정할 수 없습니다 빼고 일단 동작하는 것을 테스트 완료했습니다.