### PR TITLE
✨ feat: RegisterLayout 컴포넌트 구현

### DIFF
--- a/src/components/layout/RegisterLayout.tsx
+++ b/src/components/layout/RegisterLayout.tsx
@@ -37,7 +37,7 @@ export default function RegisterLayout({
   const { header, content, buttonText, link } = TEXT_MAP[type];
 
   return (
-    <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
+    <div className="mx-12 flex flex-col gap-16 pt-40 pb-80 md:mx-32 md:gap-24 md:pt-60 md:pb-120 lg:mx-auto lg:w-964">
       <h1 className="text-h3 font-bold md:text-h1">{header}</h1>
       <div className="flex flex-col items-center gap-16 rounded-[12px] border border-gray-20 px-24 py-60 md:gap-24">
         <p className="text-body2/22 md:text-body1/26">{content}</p>

--- a/src/components/layout/RegisterLayout.tsx
+++ b/src/components/layout/RegisterLayout.tsx
@@ -14,12 +14,24 @@ const TEXT_MAP = {
     buttonText: '가게 등록하기',
     link: '/owner/store/edit',
   },
+  application: {
+    header: '신청 내역',
+    content: '아직 신청 내역이 없어요.',
+    buttonText: '공고 보러가기',
+    link: '/',
+  },
+  notice: {
+    header: '등록한 공고',
+    content: '공고를 등록해 보세요.',
+    buttonText: '공고 등록하기',
+    link: '/owner/post',
+  },
 };
 
 export default function RegisterLayout({
   type,
 }: {
-  type: 'profile' | 'store';
+  type: 'profile' | 'store' | 'application' | 'notice';
 }) {
   const navigate = useNavigate();
   const { header, content, buttonText, link } = TEXT_MAP[type];

--- a/src/components/layout/RegisterLayout.tsx
+++ b/src/components/layout/RegisterLayout.tsx
@@ -1,0 +1,42 @@
+import { useNavigate } from 'react-router-dom';
+import Button from '../common/Button';
+
+const TEXT_MAP = {
+  profile: {
+    header: '내 프로필',
+    content: '내 프로필을 등록하고 원하는 가게에 지원해 보세요.',
+    buttonText: '내 프로필 등록하기',
+    link: '/profile/edit',
+  },
+  store: {
+    header: '내 가게',
+    content: '내 가게를 소개하고 공고도 등록해 보세요.',
+    buttonText: '가게 등록하기',
+    link: '/owner/store/edit',
+  },
+};
+
+export default function RegisterLayout({
+  type,
+}: {
+  type: 'profile' | 'store';
+}) {
+  const navigate = useNavigate();
+  const { header, content, buttonText, link } = TEXT_MAP[type];
+
+  return (
+    <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
+      <h1 className="text-h3 font-bold md:text-h1">{header}</h1>
+      <div className="flex flex-col items-center gap-16 rounded-[12px] border border-gray-20 px-24 py-60 md:gap-24">
+        <p className="text-body2/22 md:text-body1/26">{content}</p>
+        <Button
+          size="medium"
+          className="px-20 py-10 md:h-48 md:w-344 md:text-body1 md:font-bold"
+          onClick={() => navigate(link)}
+        >
+          {buttonText}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/RegisterLayout.tsx
+++ b/src/components/layout/RegisterLayout.tsx
@@ -3,25 +3,21 @@ import Button from '../common/Button';
 
 const TEXT_MAP = {
   profile: {
-    header: '내 프로필',
     content: '내 프로필을 등록하고 원하는 가게에 지원해 보세요.',
     buttonText: '내 프로필 등록하기',
     link: '/profile/edit',
   },
   store: {
-    header: '내 가게',
     content: '내 가게를 소개하고 공고도 등록해 보세요.',
     buttonText: '가게 등록하기',
     link: '/owner/store/edit',
   },
   application: {
-    header: '신청 내역',
     content: '아직 신청 내역이 없어요.',
     buttonText: '공고 보러가기',
     link: '/',
   },
   notice: {
-    header: '등록한 공고',
     content: '공고를 등록해 보세요.',
     buttonText: '공고 등록하기',
     link: '/owner/post',
@@ -34,21 +30,18 @@ export default function RegisterLayout({
   type: 'profile' | 'store' | 'application' | 'notice';
 }) {
   const navigate = useNavigate();
-  const { header, content, buttonText, link } = TEXT_MAP[type];
+  const { content, buttonText, link } = TEXT_MAP[type];
 
   return (
-    <div className="mx-12 flex flex-col gap-16 pt-40 pb-80 md:mx-32 md:gap-24 md:pt-60 md:pb-120 lg:mx-auto lg:w-964">
-      <h1 className="text-h3 font-bold md:text-h1">{header}</h1>
-      <div className="flex flex-col items-center gap-16 rounded-[12px] border border-gray-20 px-24 py-60 md:gap-24">
-        <p className="text-body2/22 md:text-body1/26">{content}</p>
-        <Button
-          size="medium"
-          className="px-20 py-10 md:h-48 md:w-344 md:text-body1 md:font-bold"
-          onClick={() => navigate(link)}
-        >
-          {buttonText}
-        </Button>
-      </div>
+    <div className="flex flex-col items-center gap-16 rounded-[12px] border border-gray-20 px-24 py-60 md:gap-24">
+      <p className="text-body2/22 md:text-body1/26">{content}</p>
+      <Button
+        size="medium"
+        className="px-20 py-10 md:h-48 md:w-344 md:text-body1 md:font-bold"
+        onClick={() => navigate(link)}
+      >
+        {buttonText}
+      </Button>
     </div>
   );
 }

--- a/src/components/layout/RegisterLayout.tsx
+++ b/src/components/layout/RegisterLayout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../common/Button';
 
@@ -31,13 +32,29 @@ export default function RegisterLayout({
 }) {
   const navigate = useNavigate();
   const { content, buttonText, link } = TEXT_MAP[type];
+  const [buttonSize, setButtonSize] = useState('medium');
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setButtonSize('large');
+      } else {
+        setButtonSize('medium');
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   return (
     <div className="flex flex-col items-center gap-16 rounded-[12px] border border-gray-20 px-24 py-60 md:gap-24">
       <p className="text-body2/22 md:text-body1/26">{content}</p>
       <Button
-        size="medium"
-        className="px-20 py-10 md:h-48 md:w-344 md:text-body1 md:font-bold"
+        size={buttonSize}
+        className="px-20 py-10 md:w-346"
         onClick={() => navigate(link)}
       >
         {buttonText}

--- a/src/components/layout/RegisterLayout.tsx
+++ b/src/components/layout/RegisterLayout.tsx
@@ -32,7 +32,7 @@ export default function RegisterLayout({
 }) {
   const navigate = useNavigate();
   const { content, buttonText, link } = TEXT_MAP[type];
-  const [buttonSize, setButtonSize] = useState('medium');
+  const [buttonSize, setButtonSize] = useState<'large' | 'medium'>('medium');
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/pages/profile/ProfileForm.tsx
+++ b/src/pages/profile/ProfileForm.tsx
@@ -1,3 +1,8 @@
+import RegisterLayout from '@/components/layout/RegisterLayout';
 export default function ProfileForm() {
-  return <div>내 프로필 등록/편집 (알바님)</div>;
+  return (
+    <div>
+      <RegisterLayout type="store" />
+    </div>
+  );
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
내 프로필 상세 페이지와 가게 정보 상세 페이지에서 등록 전의 레이아웃이 겹치므로 해당 레이아웃을 분리했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
### RegisterLayout 컴포넌트 제작
- type은 profile, store, application, notice로 주어집니다.
  - profile: 내 프로필 등록 전
  - store: 내 가게 등록 전
  - application: 알바 지원 전
  - notice: 공고 올리기 전

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #117 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

### profile: 가게 등록 전
![Image](https://github.com/user-attachments/assets/bfa18efd-e37e-45ad-9e44-bb9925d76013)

### store: 프로필 등록 전
![Image](https://github.com/user-attachments/assets/bef3769e-029f-49cc-a6b3-a453828e12bb)

### application: 알바 지원 전
![image](https://github.com/user-attachments/assets/dfd79738-c7ad-4789-a1c0-9fbc819c8a03)

### notice: 공고 올리기 전
![image](https://github.com/user-attachments/assets/f1ff715d-95db-427b-a673-097ed14ac32b)

## 💡 참고 사항
- 주영님이 구현해두신 버튼의 size prop으로 버튼의 크기를 조절할 수 있다는 걸 알고 있습니다. 
다만, 현재 모바일에서는 버튼의 size가 medium 이고 태블릿 이상부터는 버튼의 size가 large입니다.
화면의 크기에 따라 버튼의 size를 다르게 주려면 window.innerwidth를 사용해야 하는데, 이것보단 그냥 tailwind의 반응형 속성을 활용하는게 더 편할 것 같아서, size는 medium으로 두고, large 사이즈는 클래스로 구현했습니다.