### PR TITLE
✨ feat: 공고 등록 (StoreForm) 페이지 구현

### DIFF
--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect, useCallback, useContext } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { AuthContext } from '@/context/AuthContext';
 import { getUser, putUser, type SeoulDistrict } from '@/api/userApi';
 import Dropdown from '@/components/common/Dropdown';
 import Input from '@/components/common/Input';
@@ -11,7 +10,6 @@ import { ADDRESS_OPTIONS } from '@/constants/dropdownOptions';
 
 export default function StoreForm() {
   const navigate = useNavigate();
-  const { isLoggedIn } = useContext(AuthContext);
   // 사용자 입력값 상태 (이름, 전화번호, 소개글)
   const [profileInfo, setProfileInfo] = useState({
     name: '',
@@ -30,41 +28,34 @@ export default function StoreForm() {
   });
 
   useEffect(() => {
-    if (isLoggedIn) {
-      const userId = localStorage.getItem('userId');
+    const userId = localStorage.getItem('userId');
 
-      if (!userId) {
-        setModal({
-          isOpen: true,
-          message: '사용자 정보를 가져올 수 없습니다. 다시 로그인해주세요.',
-        });
-        return;
-      }
-
-      const fetchUserInfo = async () => {
-        try {
-          const userInfo = await getUser(userId);
-          setProfileInfo({
-            name: userInfo.item.name ?? '',
-            phone: userInfo.item.phone ?? '',
-            bio: userInfo.item.bio ?? '',
-          });
-          setSelectedAddress((userInfo.item.address as SeoulDistrict) ?? '');
-        } catch (error) {
-          setModal({
-            isOpen: true,
-            message: (error as Error).message,
-          });
-        }
-      };
-      fetchUserInfo();
-    } else {
+    if (!userId) {
       setModal({
         isOpen: true,
         message: '로그인이 필요합니다.',
       });
+      return;
     }
-  }, [isLoggedIn]);
+
+    const fetchUserInfo = async () => {
+      try {
+        const userInfo = await getUser(userId);
+        setProfileInfo({
+          name: userInfo.item.name ?? '',
+          phone: userInfo.item.phone ?? '',
+          bio: userInfo.item.bio ?? '',
+        });
+        setSelectedAddress((userInfo.item.address as SeoulDistrict) ?? '');
+      } catch (error) {
+        setModal({
+          isOpen: true,
+          message: (error as Error).message,
+        });
+      }
+    };
+    fetchUserInfo();
+  }, []);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -83,7 +74,7 @@ export default function StoreForm() {
     const { name, phone, bio } = profileInfo;
     const userId = localStorage.getItem('userId');
     // 로그인이 안된 상태에 대한 처리
-    if (!isLoggedIn || !userId) {
+    if (!userId) {
       setModal({
         isOpen: true,
         message: '로그인이 필요합니다.',

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -9,9 +9,12 @@ import close from '@/assets/icons/close.svg';
 
 export default function StoreForm() {
   const navigate = useNavigate();
-  const [noticeInfo, setNoticeInfo] = useState<Partial<NoticeUpsertRequest>>(
-    {},
-  );
+  const [noticeInfo, setNoticeInfo] = useState<Partial<NoticeUpsertRequest>>({
+    hourlyPay: undefined,
+    startsAt: '',
+    workhour: undefined,
+    description: '',
+  });
   const shopId = useRef('');
   const noticeId = useRef('');
 

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -16,6 +16,7 @@ export default function StoreForm() {
     description: '',
   });
   const shopId = useRef('');
+  const noticeId = useRef('');
 
   const [modal, setModal] = useState({
     isOpen: false,
@@ -80,10 +81,11 @@ export default function StoreForm() {
 
     try {
       const startsTime = new Date(noticeInfo?.startsAt).toISOString();
-      await postShopNotice(shopId.current, {
+      const { item } = await postShopNotice(shopId.current, {
         ...noticeInfo,
         startsAt: startsTime,
       });
+      noticeId.current = item.id;
       setModal({
         isOpen: true,
         message: '등록이 완료되었습니다.',
@@ -99,7 +101,7 @@ export default function StoreForm() {
   const handleModalConfirm = useCallback(() => {
     if (modal.message === '등록이 완료되었습니다.') {
       setModal({ isOpen: false, message: '' });
-      navigate('/profile');
+      navigate(`/owner/post/${noticeId.current}`);
     } else if (modal.message.includes('로그인')) {
       setModal({ isOpen: false, message: '' });
       navigate('/login');

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -115,7 +115,7 @@ export default function StoreForm() {
       <div className="mx-12 flex flex-col gap-24 pt-40 pb-80 md:mx-32 md:gap-32 md:py-60 lg:mx-auto lg:w-964">
         <div className="flex items-center justify-between">
           <h1 className="text-h3/24 font-bold md:text-h1/34">내 프로필</h1>
-          <Link to="/profile">
+          <Link to="/owner/store">
             <img src={close} alt="닫기" className="md:size-32" />
           </Link>
         </div>

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -9,12 +9,9 @@ import close from '@/assets/icons/close.svg';
 
 export default function StoreForm() {
   const navigate = useNavigate();
-  const [noticeInfo, setNoticeInfo] = useState<NoticeUpsertRequest>({
-    hourlyPay: 0,
-    startsAt: '',
-    workhour: 0,
-    description: '',
-  });
+  const [noticeInfo, setNoticeInfo] = useState<Partial<NoticeUpsertRequest>>(
+    {},
+  );
   const shopId = useRef('');
   const noticeId = useRef('');
 
@@ -70,7 +67,6 @@ export default function StoreForm() {
       return;
     }
 
-    // 시작 일시가 선택되지 않은 경우
     if (!noticeInfo?.startsAt) {
       setModal({
         isOpen: true,
@@ -82,8 +78,10 @@ export default function StoreForm() {
     try {
       const startsTime = new Date(noticeInfo?.startsAt).toISOString();
       const { item } = await postShopNotice(shopId.current, {
-        ...noticeInfo,
+        hourlyPay: noticeInfo?.hourlyPay ?? 0,
         startsAt: startsTime,
+        workhour: noticeInfo?.workhour ?? 0,
+        description: noticeInfo?.description ?? '',
       });
       noticeId.current = item.id;
       setModal({

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -1,3 +1,207 @@
+import { useState, useEffect, useCallback, useContext } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '@/context/AuthContext';
+import { getUser, putUser, type SeoulDistrict } from '@/api/userApi';
+import Dropdown from '@/components/common/Dropdown';
+import Input from '@/components/common/Input';
+import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import close from '@/assets/icons/close.svg';
+import { ADDRESS_OPTIONS } from '@/constants/dropdownOptions';
+
 export default function StoreForm() {
-  return <div>내 가게 공고 등록</div>;
+  const navigate = useNavigate();
+  const { isLoggedIn } = useContext(AuthContext);
+  // 사용자 입력값 상태 (이름, 전화번호, 소개글)
+  const [profileInfo, setProfileInfo] = useState({
+    name: '',
+    phone: '',
+    bio: '',
+  });
+
+  // dropdown 컴포넌트에 set함수를 전달하기 위해 address는 따로 분리
+  const [selectedAddress, setSelectedAddress] = useState<SeoulDistrict | null>(
+    null,
+  );
+
+  const [modal, setModal] = useState({
+    isOpen: false,
+    message: '',
+  });
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      const userId = localStorage.getItem('userId');
+
+      if (!userId) {
+        setModal({
+          isOpen: true,
+          message: '사용자 정보를 가져올 수 없습니다. 다시 로그인해주세요.',
+        });
+        return;
+      }
+
+      const fetchUserInfo = async () => {
+        try {
+          const userInfo = await getUser(userId);
+          setProfileInfo({
+            name: userInfo.item.name ?? '',
+            phone: userInfo.item.phone ?? '',
+            bio: userInfo.item.bio ?? '',
+          });
+          setSelectedAddress((userInfo.item.address as SeoulDistrict) ?? '');
+        } catch (error) {
+          setModal({
+            isOpen: true,
+            message: (error as Error).message,
+          });
+        }
+      };
+      fetchUserInfo();
+    } else {
+      setModal({
+        isOpen: true,
+        message: '로그인이 필요합니다.',
+      });
+    }
+  }, [isLoggedIn]);
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    const { name, value } = e.target;
+    const sanitized = name === 'phone' ? value.replace(/[^0-9]/g, '') : value; // phone은 숫자만 입력 가능하도록 설정
+
+    setProfileInfo((prev) => ({
+      ...prev,
+      [name]: sanitized,
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const { name, phone, bio } = profileInfo;
+    const userId = localStorage.getItem('userId');
+    // 로그인이 안된 상태에 대한 처리
+    if (!isLoggedIn || !userId) {
+      setModal({
+        isOpen: true,
+        message: '로그인이 필요합니다.',
+      });
+      return;
+    }
+
+    // 이름이 입력되지 않은 경우
+    if (!name.trim()) {
+      setModal({
+        isOpen: true,
+        message: '이름을 입력해주세요.',
+      });
+      return;
+    }
+
+    // 지역이 선택되지 않은 경우
+    if (!selectedAddress) {
+      setModal({
+        isOpen: true,
+        message: '선호 지역을 선택해주세요',
+      });
+      return;
+    }
+
+    try {
+      await putUser(userId, {
+        name,
+        phone,
+        address: selectedAddress,
+        bio,
+      });
+      setModal({
+        isOpen: true,
+        message: '등록이 완료되었습니다.',
+      });
+    } catch (error) {
+      setModal({
+        isOpen: true,
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  const handleModalConfirm = useCallback(() => {
+    if (modal.message === '등록이 완료되었습니다.') {
+      setModal({ isOpen: false, message: '' });
+      navigate('/profile');
+    } else if (modal.message.includes('로그인')) {
+      setModal({ isOpen: false, message: '' });
+      navigate('/login');
+    } else {
+      setModal({ isOpen: false, message: '' });
+    }
+  }, [modal.message, navigate]);
+
+  return (
+    <div className="min-h-[calc(100vh-102px)] bg-gray-5 md:min-h-[calc(100vh-70px)]">
+      <div className="mx-12 flex flex-col gap-24 pt-40 pb-80 md:mx-32 md:gap-32 md:py-60 lg:mx-auto lg:w-964">
+        <div className="flex items-center justify-between">
+          <h1 className="text-h3/24 font-bold md:text-h1/34">내 프로필</h1>
+          <Link to="/profile">
+            <img src={close} alt="닫기" className="md:size-32" />
+          </Link>
+        </div>
+        <form
+          className="flex flex-col gap-24 md:gap-32"
+          onSubmit={handleSubmit}
+        >
+          <div className="flex flex-col gap-20 md:gap-24">
+            <div className="grid grid-cols-1 gap-20 md:grid-cols-2 md:gap-y-24 lg:grid-cols-3">
+              <Input
+                label="이름*"
+                name="name"
+                value={profileInfo.name}
+                onChange={handleChange}
+              />
+              <Input
+                label="연락처*"
+                type="tel"
+                name="phone"
+                maxLength={11}
+                value={profileInfo.phone}
+                onChange={handleChange}
+              />
+              <div className="flex flex-col gap-8 text-body1/26 font-regular">
+                <label htmlFor="region">선호 지역*</label>
+                <Dropdown
+                  id="region"
+                  variant="form"
+                  options={ADDRESS_OPTIONS}
+                  selected={selectedAddress}
+                  setSelect={setSelectedAddress}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-8 text-body1/26 font-regular">
+              <label htmlFor="bio">소개</label>
+              <textarea
+                name="bio"
+                id="bio"
+                className="h-153 resize-none rounded-[5px] border border-gray-30 bg-white px-20 py-16 placeholder-gray-40"
+                placeholder="입력"
+                value={profileInfo.bio}
+                onChange={handleChange}
+              ></textarea>
+            </div>
+          </div>
+          <Button type="submit" className="md:mx-auto md:w-312">
+            등록하기
+          </Button>
+        </form>
+      </div>
+      {modal.isOpen && (
+        <Modal onClose={handleModalConfirm} onButtonClick={handleModalConfirm}>
+          {modal.message}
+        </Modal>
+      )}
+    </div>
+  );
 }

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -51,10 +51,12 @@ export default function StoreForm() {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) {
     const { name, value } = e.target;
+    const sanitized =
+      name === 'hourlyPay' ? Number(value.replace(/[^0-9]/g, '')) : value;
 
     setNoticeInfo((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: sanitized,
     }));
   }
 
@@ -128,17 +130,16 @@ export default function StoreForm() {
             <div className="grid grid-cols-1 gap-20 md:grid-cols-2 md:gap-y-24 lg:grid-cols-3">
               <Input
                 label="시급*"
-                type="number"
                 name="hourlyPay"
                 unit="원"
-                value={noticeInfo?.hourlyPay}
+                value={noticeInfo.hourlyPay?.toLocaleString('ko-KR')}
                 onChange={handleChange}
               />
               <Input
                 label="시작 일시*"
                 type="datetime-local"
                 name="startsAt"
-                value={noticeInfo?.startsAt}
+                value={noticeInfo.startsAt}
                 onChange={handleChange}
               />
               <Input
@@ -146,7 +147,7 @@ export default function StoreForm() {
                 type="number"
                 name="workhour"
                 unit="시간"
-                value={noticeInfo?.workhour}
+                value={noticeInfo.workhour}
                 onChange={handleChange}
               />
             </div>
@@ -157,7 +158,7 @@ export default function StoreForm() {
                 id="description"
                 className="h-153 resize-none rounded-[5px] border border-gray-30 bg-white px-20 py-16 placeholder-gray-40"
                 placeholder="입력"
-                value={noticeInfo?.description}
+                value={noticeInfo.description}
                 onChange={handleChange}
               />
             </div>


### PR DESCRIPTION
## 📌 변경 사항 개요

- 공고 등록 (StoreForm) 페이지 컴포넌트를 구현했습니다.

## 📝 상세 내용

- 공고 등록(post) 부분을 구현했습니다. **편집 기능은 없습니다.**
- 시작 일시는 input 기본 type `datetime-local`을 사용했습니다.
- X 버튼 클릭시 가게 정보 상세 페이지로 돌아갑니다.

## 🔗 관련 이슈

Resolves: #88

## 🖼️ 스크린샷(선택사항)

https://github.com/user-attachments/assets/728a973e-2213-4559-8a72-a7593bc920f1

## 💡 참고 사항

- `ProfileForm`을 복사해 와 매우 유사하게 구현했습니다.
- 제어/비제어 컴포넌트 문제인지 console에 error가 뜨기는 하나 동작 자체에는 문제가 없어 고치지는 않았습니다. (시도는 해봤는데 복잡해서 고치려고 한다면 조금 걸릴 듯 합니다)