### PR TITLE
🐛 fix: url 경로 수정 및 post 컴포넌트 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
       <Routes>
         {/* 공통 페이지 */}
         <Route path="/" element={<NoticeList />} />
-        <Route path=":id" element={<Notice />} />
+        <Route path=":shopId/:userId" element={<Notice />} />
         <Route path="login" element={<Login />} />
         <Route path="signup" element={<Signup />} />
 
@@ -32,7 +32,7 @@ export default function App() {
           </Route>
           <Route path="post">
             <Route index element={<StoreForm />} />
-            <Route path=":id" element={<StorePost />} />
+            <Route path=":shopId/:userId" element={<StorePost />} />
           </Route>
         </Route>
 

--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -1,3 +1,4 @@
+import { useNavigate, useLocation } from 'react-router-dom';
 import formatWorkTime from '@/utils/formatWorkTime';
 import ClockRed from '@/assets/icons/clock-red.svg';
 import ClockGray from '@/assets/icons/clock-gray.svg';
@@ -26,15 +27,17 @@ function getStatus(
 
 export default function Post({ data }: { data: NoticeShopItem }) {
   const {
+    id: noticeId,
     hourlyPay,
     workhour,
     startsAt,
     closed,
     shop: {
-      item: { name, address1, imageUrl, originalHourlyPay },
+      item: { id: shopId, name, address1, imageUrl, originalHourlyPay },
     },
   } = data;
-
+  const navigate = useNavigate();
+  const location = useLocation();
   const status = getStatus(startsAt, closed);
   const isInactive = status !== 'ACTIVE';
   const overlayText = isInactive
@@ -79,8 +82,20 @@ export default function Post({ data }: { data: NoticeShopItem }) {
     }
   }
 
+  const handleClick = () => {
+    const isOwnerPage = location.pathname.startsWith('/owner/store');
+
+    const path = isOwnerPage
+      ? `/owner/post/${shopId}/${noticeId}`
+      : `/${shopId}/${noticeId}`;
+
+    navigate(path);
+  };
   return (
-    <div className="flex h-261 w-full cursor-pointer flex-col gap-12 rounded-xl border border-gray-20 bg-white p-12 md:h-359 md:gap-20 md:p-16 lg:h-348">
+    <div
+      onClick={handleClick}
+      className="flex h-261 w-full cursor-pointer flex-col gap-12 rounded-xl border border-gray-20 bg-white p-12 md:h-359 md:gap-20 md:p-16 lg:h-348"
+    >
       <div className="relative">
         <div
           className="relative h-84 w-full rounded-xl bg-cover bg-center md:h-171 lg:h-160"

--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -83,7 +83,7 @@ export default function Post({ data }: { data: NoticeShopItem }) {
   }
 
   const handleClick = () => {
-    const isOwnerPage = location.pathname.startsWith('/owner/store');
+    const isOwnerPage = location.pathname.startsWith('/owner');
 
     const path = isOwnerPage
       ? `/owner/post/${shopId}/${noticeId}`

--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -92,7 +92,7 @@ export default function Post({ data }: { data: NoticeShopItem }) {
     navigate(path);
   };
   return (
-    <div
+    <button
       onClick={handleClick}
       className="flex h-261 w-full cursor-pointer flex-col gap-12 rounded-xl border border-gray-20 bg-white p-12 md:h-359 md:gap-20 md:p-16 lg:h-348"
     >
@@ -167,6 +167,6 @@ export default function Post({ data }: { data: NoticeShopItem }) {
           )}
         </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -104,7 +104,7 @@ export default function StoreForm() {
   const handleModalConfirm = useCallback(() => {
     if (modal.message === '등록이 완료되었습니다.') {
       setModal({ isOpen: false, message: '' });
-      navigate(`/owner/post/${shopId.curren}/${noticeId.current}`);
+      navigate(`/owner/post/${shopId.current}/${noticeId.current}`);
     } else if (modal.message.includes('로그인')) {
       setModal({ isOpen: false, message: '' });
       navigate('/login');

--- a/src/pages/store/StoreForm.tsx
+++ b/src/pages/store/StoreForm.tsx
@@ -104,7 +104,7 @@ export default function StoreForm() {
   const handleModalConfirm = useCallback(() => {
     if (modal.message === '등록이 완료되었습니다.') {
       setModal({ isOpen: false, message: '' });
-      navigate(`/owner/post/${noticeId.current}`);
+      navigate(`/owner/post/${shopId.curren}/${noticeId.current}`);
     } else if (modal.message.includes('로그인')) {
       setModal({ isOpen: false, message: '' });
       navigate('/login');


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
현재 공고 상세 페이지의 경로에 noticeId만 포함되어 있는데, shopId도 포함시켰습니다.
post 컴포넌트를 클릭 시 해당 공고 상세 페이지로 이동하도록 onClick속성 추가했습니다.



## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- 내 가게 공고 상세 (사장님) | /owner/post/{shopId}/{noticeId}
- 공고 상세 | /{shopId}/{noticeId}
- Post 클릭 시 해당 공고 상세 페이지로 이동
  

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #132 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항
공고 상세 페이지가 2개인데, 내 가게의 공고일 경우에 어떻게 내 가게 공고 상세 페이지로 이동시킬 지 고민을 했는데, /owner로 시작하는 경로는 내 가게에 대한 페이지들이므로, 
/owner로 시작하는 페이지에서 post를 클릭 시 내 가게 공고 상세 페이지로 이동하며, 
나머지 경우(공고 리스트 페이지)에서는 공고 상세 페이지로 이동하도록 했습니다.