### PR TITLE
✨ feat: PostLarge 컴포넌트 구현

### DIFF
--- a/src/api/noticeApi.ts
+++ b/src/api/noticeApi.ts
@@ -32,7 +32,7 @@ export interface NoticeShopItem extends NoticeItem {
 
 // application까지 포함된 상세형 Notice (상세 조회 시 사용)
 export interface NoticeDetailItem extends NoticeShopItem {
-  currentUserApplication?: {
+  currentUserApplication: null | {
     item: ApplicationItem;
   };
 }

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -1,0 +1,3 @@
+export default function PostLarge() {
+  return;
+}

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -66,27 +66,32 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
       </div>
       <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346">
         <div className="flex flex-col gap-8 text-body2/22 font-regular md:gap-12 md:text-body1/26">
-          <div
-            className="flex items-center gap-4 md:gap-8"
-            title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
-          >
-            <div className="text-h2/29 font-bold md:text-h1/34">
-              {hourlyPay.toLocaleString()}원
+          <div>
+            <div className="mb-8 leading-17 font-bold text-primary md:leading-20">
+              시급
             </div>
-            {isHigherPay && status === 'ACTIVE' && (
-              <div
-                className={`flex h-24 items-center justify-center gap-2 rounded-full px-8 py-4 text-caption/16 text-white md:h-36 md:p-12 md:text-body2 md:font-bold ${badgeBgColor}`}
-              >
-                <div className="max-w-122 truncate">
-                  기존 시급보다 {percent}%
-                </div>
-                <img
-                  src={ic_arrow}
-                  alt="위 화살표"
-                  className="size-16 md:size-20"
-                />
+            <div
+              className="flex items-center gap-4 md:gap-8"
+              title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
+            >
+              <div className="text-h2/29 font-bold md:text-h1/34">
+                {hourlyPay.toLocaleString()}원
               </div>
-            )}
+              {isHigherPay && status === 'ACTIVE' && (
+                <div
+                  className={`flex h-24 items-center justify-center gap-2 rounded-full px-8 py-4 text-caption/16 text-white md:h-36 md:p-12 md:text-body2 md:font-bold ${badgeBgColor}`}
+                >
+                  <div className="max-w-122 truncate">
+                    기존 시급보다 {percent}%
+                  </div>
+                  <img
+                    src={ic_arrow}
+                    alt="위 화살표"
+                    className="size-16 md:size-20"
+                  />
+                </div>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-6 text-gray-50">
             <img

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -52,10 +52,10 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
   }
 
   return (
-    <div className="flex h-261 w-full cursor-pointer flex-col gap-12 rounded-xl border border-gray-20 bg-white p-12 md:h-359 md:gap-20 md:p-16 lg:h-348">
-      <div className="relative">
+    <div className="flex min-h-356 flex-col items-stretch justify-between rounded-xl border border-gray-20 bg-white p-20 md:p-24 lg:flex-row">
+      <div className="relative h-178 md:h-360 lg:h-auto lg:w-539">
         <div
-          className="relative h-84 w-full rounded-xl bg-cover bg-center md:h-171 lg:h-160"
+          className="h-full w-full rounded-xl bg-cover bg-center"
           style={{ backgroundImage: `url(${background})` }}
         />
         {status === 'ACTIVE' || (
@@ -64,7 +64,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           </div>
         )}
       </div>
-      <div className="flex flex-col gap-16 text-black">
+      <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346">
         <div className="flex flex-col gap-8">
           <div
             className="truncate text-body1/20 font-bold md:text-h3/24"

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -1,7 +1,7 @@
 import formatWorkTime from '@/utils/formatWorkTime';
-import ClockRed from '@/assets/icons/clock-red.svg';
-import LocationRed from '@/assets/icons/location-red.svg';
-import ArrowUpWhite from '@/assets/icons/arrow-up-white.svg';
+import ic_clock from '@/assets/icons/clock-red.svg';
+import ic_location from '@/assets/icons/location-red.svg';
+import ic_arrow from '@/assets/icons/arrow-up-white.svg';
 import PostImg from '@/assets/images/post-default.png';
 import type { NoticeDetailItem } from '@/api/noticeApi';
 
@@ -88,7 +88,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           >
             <div className="flex items-center gap-6">
               <img
-                src={ClockRed}
+                src={ic_clock}
                 alt="시계 아이콘"
                 className="size-16 md:size-20"
               />
@@ -96,7 +96,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
             </div>
             <div className="flex items-center gap-6">
               <img
-                src={LocationRed}
+                src={ic_location}
                 alt="위치 아이콘"
                 className="size-16 md:size-20"
               />
@@ -116,7 +116,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               className={`flex h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white ${badgeBgColor}`}
             >
               <div className="max-w-168 truncate">기존 시급보다 {percent}%</div>
-              <img src={ArrowUpWhite} alt="위 화살표" className="h-20 w-20" />
+              <img src={ic_arrow} alt="위 화살표" className="h-20 w-20" />
             </div>
           )}
         </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -24,6 +24,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
     workhour,
     startsAt,
     closed,
+    description: noticeDescription,
     shop: {
       item: {
         address1,
@@ -57,66 +58,69 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
   }
 
   return (
-    <div className="flex min-h-356 flex-col items-stretch justify-between rounded-xl border border-gray-20 bg-white p-20 md:p-24 lg:flex-row">
-      <div className="relative h-178 md:h-360 lg:h-auto lg:w-539">
-        <div
-          className="h-full w-full rounded-xl bg-cover bg-center"
-          style={{ backgroundImage: `url(${background})` }}
-        />
-        {status === 'ACTIVE' || (
-          <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-[#000000]/70 text-h3 font-bold text-gray-30 md:text-h1">
-            {overlayText}
-          </div>
-        )}
-      </div>
-      <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346 lg:gap-0">
-        <div className="flex flex-col gap-8 text-body2/22 font-regular md:gap-12 md:text-body1/26">
-          <div>
-            <div className="mb-8 leading-17 font-bold text-primary md:leading-20">
-              시급
+    <div className="text-body2/22 font-regular md:text-body1/26">
+      <div className="flex min-h-356 flex-col items-stretch justify-between rounded-xl border border-gray-20 bg-white p-20 md:p-24 lg:flex-row">
+        <div className="relative h-178 md:h-360 lg:h-auto lg:w-539">
+          <div
+            className="h-full w-full rounded-xl bg-cover bg-center"
+            style={{ backgroundImage: `url(${background})` }}
+          />
+          {status === 'ACTIVE' || (
+            <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-[#000000]/70 text-h3 font-bold text-gray-30 md:text-h1">
+              {overlayText}
             </div>
-            <div
-              className="flex items-center gap-4 md:gap-8"
-              title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
-            >
-              <div className="text-h2/29 font-bold md:text-h1/34">
-                {hourlyPay.toLocaleString()}원
+          )}
+        </div>
+        <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346 lg:gap-0">
+          <div className="flex flex-col gap-8 md:gap-12">
+            <div>
+              <div className="mb-8 leading-17 font-bold text-primary md:leading-20">
+                시급
               </div>
-              {isHigherPay && status === 'ACTIVE' && (
-                <div
-                  className={`flex h-24 items-center justify-center gap-2 rounded-full px-8 py-4 text-caption/16 text-white md:h-36 md:p-12 md:text-body2 md:font-bold ${badgeBgColor}`}
-                >
-                  <div className="max-w-122 truncate">
-                    기존 시급보다 {percent}%
-                  </div>
-                  <img
-                    src={ic_arrow}
-                    alt="위 화살표"
-                    className="size-16 md:size-20"
-                  />
+              <div
+                className="flex items-center gap-4 md:gap-8"
+                title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
+              >
+                <div className="text-h2/29 font-bold md:text-h1/34">
+                  {hourlyPay.toLocaleString()}원
                 </div>
-              )}
+                {isHigherPay && status === 'ACTIVE' && (
+                  <div
+                    className={`flex h-24 items-center justify-center gap-2 rounded-full px-8 py-4 text-caption/16 text-white md:h-36 md:p-12 md:text-body2 md:font-bold ${badgeBgColor}`}
+                  >
+                    <div className="max-w-122 truncate">
+                      기존 시급보다 {percent}%
+                    </div>
+                    <img
+                      src={ic_arrow}
+                      alt="위 화살표"
+                      className="size-16 md:size-20"
+                    />
+                  </div>
+                )}
+              </div>
             </div>
+            <div className="flex items-center gap-6 text-gray-50">
+              <img
+                src={ic_clock}
+                alt="시계 아이콘"
+                className="size-16 md:size-20"
+              />
+              {dateTime}
+            </div>
+            <div className="flex items-center gap-6 text-gray-50">
+              <img
+                src={ic_location}
+                alt="위치 아이콘"
+                className="size-16 md:size-20"
+              />
+              {address1}
+            </div>
+            {shopDescription}
           </div>
-          <div className="flex items-center gap-6 text-gray-50">
-            <img
-              src={ic_clock}
-              alt="시계 아이콘"
-              className="size-16 md:size-20"
-            />
-            {dateTime}
-          </div>
-          <div className="flex items-center gap-6 text-gray-50">
-            <img
-              src={ic_location}
-              alt="위치 아이콘"
-              className="size-16 md:size-20"
-            />
-            {address1}
-          </div>
-          {shopDescription}
         </div>
       </div>
+      <div>{noticeDescription}</div>
     </div>
   );
 }

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -94,7 +94,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               alt="시계 아이콘"
               className="size-16 md:size-20"
             />
-            <span>{dateTime}</span>
+            {dateTime}
           </div>
           <div className="flex items-center gap-6 text-gray-50">
             <img
@@ -102,7 +102,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               alt="위치 아이콘"
               className="size-16 md:size-20"
             />
-            <span>{address1}</span>
+            {address1}
           </div>
         </div>
       </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -25,7 +25,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
     startsAt,
     closed,
     shop: {
-      item: { name, address1, imageUrl, originalHourlyPay },
+      item: { address1, imageUrl, originalHourlyPay },
     },
   } = data;
 
@@ -66,12 +66,6 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
       </div>
       <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346">
         <div className="flex flex-col gap-8">
-          <div
-            className="truncate text-body1/20 font-bold md:text-h3/24"
-            title={`${name}`}
-          >
-            {name}
-          </div>
           <div
             className="flex flex-col justify-between md:flex-row md:items-center"
             title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -67,10 +67,10 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
       <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346">
         <div className="flex flex-col gap-8">
           <div
-            className="flex flex-col justify-between md:flex-row md:items-center"
+            className="flex items-center gap-4 md:gap-8"
             title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
           >
-            <div className="truncate text-lg/23 font-bold md:text-h2/29 lg:max-w-110">
+            <div className="text-h2/29 font-bold md:text-h1/34">
               {hourlyPay.toLocaleString()}원
             </div>
             {isHigherPay && status === 'ACTIVE' && (

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -1,8 +1,6 @@
 import formatWorkTime from '@/utils/formatWorkTime';
 import ClockRed from '@/assets/icons/clock-red.svg';
-import ClockGray from '@/assets/icons/clock-gray.svg';
 import LocationRed from '@/assets/icons/location-red.svg';
-import LocationGray from '@/assets/icons/location-gray.svg';
 import ArrowUpWhite from '@/assets/icons/arrow-up-white.svg';
 import PostImg from '@/assets/images/post-default.png';
 import type { NoticeDetailItem } from '@/api/noticeApi';
@@ -45,9 +43,6 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
     ((hourlyPay - originalHourlyPay) / originalHourlyPay) * 100,
   );
   const isHigherPay = percent > 0; // 이전 시급보다 높을 때만 표시
-
-  const clockIcon = isInactive ? ClockGray : ClockRed;
-  const locationIcon = isInactive ? LocationGray : LocationRed;
 
   const background = imageUrl ?? PostImg;
 
@@ -93,7 +88,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           >
             <div className="flex items-center gap-6">
               <img
-                src={clockIcon}
+                src={ClockRed}
                 alt="시계 아이콘"
                 className="size-16 md:size-20"
               />
@@ -101,7 +96,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
             </div>
             <div className="flex items-center gap-6">
               <img
-                src={locationIcon}
+                src={LocationRed}
                 alt="위치 아이콘"
                 className="size-16 md:size-20"
               />

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -25,7 +25,12 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
     startsAt,
     closed,
     shop: {
-      item: { address1, imageUrl, originalHourlyPay },
+      item: {
+        address1,
+        imageUrl,
+        originalHourlyPay,
+        description: shopDescription,
+      },
     },
   } = data;
 
@@ -64,7 +69,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           </div>
         )}
       </div>
-      <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346">
+      <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346 lg:gap-0">
         <div className="flex flex-col gap-8 text-body2/22 font-regular md:gap-12 md:text-body1/26">
           <div>
             <div className="mb-8 leading-17 font-bold text-primary md:leading-20">
@@ -109,6 +114,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
             />
             {address1}
           </div>
+          {shopDescription}
         </div>
       </div>
     </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -72,6 +72,24 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           >
             {name}
           </div>
+          <div
+            className="flex flex-col justify-between md:flex-row md:items-center"
+            title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
+          >
+            <div className="truncate text-lg/23 font-bold md:text-h2/29 lg:max-w-110">
+              {hourlyPay.toLocaleString()}원
+            </div>
+            {isHigherPay && status === 'ACTIVE' && (
+              <div
+                className={`flex h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white ${badgeBgColor}`}
+              >
+                <div className="max-w-168 truncate">
+                  기존 시급보다 {percent}%
+                </div>
+                <img src={ic_arrow} alt="위 화살표" className="h-20 w-20" />
+              </div>
+            )}
+          </div>
           <div className="flex flex-col gap-8 text-caption/16 font-regular text-gray-50 md:text-body2/22">
             <div className="flex items-center gap-6">
               <img
@@ -90,22 +108,6 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               <span>{address1}</span>
             </div>
           </div>
-        </div>
-        <div
-          className="flex flex-col justify-between md:flex-row md:items-center"
-          title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
-        >
-          <div className="truncate text-lg/23 font-bold md:text-h2/29 lg:max-w-110">
-            {hourlyPay.toLocaleString()}원
-          </div>
-          {isHigherPay && status === 'ACTIVE' && (
-            <div
-              className={`flex h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white ${badgeBgColor}`}
-            >
-              <div className="max-w-168 truncate">기존 시급보다 {percent}%</div>
-              <img src={ic_arrow} alt="위 화살표" className="h-20 w-20" />
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -4,10 +4,6 @@ import ClockGray from '@/assets/icons/clock-gray.svg';
 import LocationRed from '@/assets/icons/location-red.svg';
 import LocationGray from '@/assets/icons/location-gray.svg';
 import ArrowUpWhite from '@/assets/icons/arrow-up-white.svg';
-import ArrowUpGray from '@/assets/icons/arrow-up-gray.svg';
-import ArrowUpRed40 from '@/assets/icons/arrow-up-red40.svg';
-import ArrowUpRed30 from '@/assets/icons/arrow-up-red30.svg';
-import ArrowUpRed20 from '@/assets/icons/arrow-up-red20.svg';
 import PostImg from '@/assets/images/post-default.png';
 import type { NoticeDetailItem } from '@/api/noticeApi';
 
@@ -56,26 +52,16 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
   const background = imageUrl ?? PostImg;
 
   let badgeBgColor = '';
-  let badgeTextColor = '';
-  let arrowIcon = '';
 
   if (isInactive) {
     badgeBgColor = 'bg-gray-20';
-    badgeTextColor = 'text-gray-20';
-    arrowIcon = ArrowUpGray;
   } else {
     if (percent >= 50) {
       badgeBgColor = 'bg-red-40';
-      badgeTextColor = 'text-red-40';
-      arrowIcon = ArrowUpRed40;
     } else if (percent >= 30) {
       badgeBgColor = 'bg-red-30';
-      badgeTextColor = 'text-red-30';
-      arrowIcon = ArrowUpRed30;
     } else if (percent >= 1) {
       badgeBgColor = 'bg-red-20 ';
-      badgeTextColor = 'text-red-20';
-      arrowIcon = ArrowUpRed20;
     }
   }
 
@@ -131,24 +117,12 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
             {hourlyPay.toLocaleString()}원
           </div>
           {isHigherPay && (
-            <>
-              {/*데스크탑, 태블릿*/}
-              <div
-                className={`hidden h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white md:flex ${badgeBgColor}`}
-              >
-                <div className="max-w-168 truncate">
-                  기존 시급보다 {percent}%
-                </div>
-                <img src={ArrowUpWhite} alt="위 화살표" className="h-20 w-20" />
-              </div>
-              {/*모바일*/}
-              <div
-                className={`flex items-center gap-2 text-caption/16 md:hidden ${badgeTextColor}`}
-              >
-                <div className="truncate">기존 시급보다 {percent}%</div>
-                <img src={arrowIcon} alt="위 화살표" className="h-16 w-16" />
-              </div>
-            </>
+            <div
+              className={`flex h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white ${badgeBgColor}`}
+            >
+              <div className="max-w-168 truncate">기존 시급보다 {percent}%</div>
+              <img src={ArrowUpWhite} alt="위 화살표" className="h-20 w-20" />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -65,7 +65,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
         )}
       </div>
       <div className="mt-12 flex flex-col justify-between gap-24 text-black md:mt-16 md:gap-40 lg:w-346">
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-8 text-body2/22 font-regular md:gap-12 md:text-body1/26">
           <div
             className="flex items-center gap-4 md:gap-8"
             title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
@@ -88,23 +88,21 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               </div>
             )}
           </div>
-          <div className="flex flex-col gap-8 text-body2/22 font-regular md:gap-12 md:text-body1/26">
-            <div className="flex items-center gap-6 text-gray-50">
-              <img
-                src={ic_clock}
-                alt="시계 아이콘"
-                className="size-16 md:size-20"
-              />
-              <span>{dateTime}</span>
-            </div>
-            <div className="flex items-center gap-6 text-gray-50">
-              <img
-                src={ic_location}
-                alt="위치 아이콘"
-                className="size-16 md:size-20"
-              />
-              <span>{address1}</span>
-            </div>
+          <div className="flex items-center gap-6 text-gray-50">
+            <img
+              src={ic_clock}
+              alt="시계 아이콘"
+              className="size-16 md:size-20"
+            />
+            <span>{dateTime}</span>
+          </div>
+          <div className="flex items-center gap-6 text-gray-50">
+            <img
+              src={ic_location}
+              alt="위치 아이콘"
+              className="size-16 md:size-20"
+            />
+            <span>{address1}</span>
           </div>
         </div>
       </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -88,8 +88,8 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               </div>
             )}
           </div>
-          <div className="flex flex-col gap-8 text-caption/16 font-regular text-gray-50 md:text-body2/22">
-            <div className="flex items-center gap-6">
+          <div className="flex flex-col gap-8 text-body2/22 font-regular md:gap-12 md:text-body1/26">
+            <div className="flex items-center gap-6 text-gray-50">
               <img
                 src={ic_clock}
                 alt="시계 아이콘"
@@ -97,7 +97,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
               />
               <span>{dateTime}</span>
             </div>
-            <div className="flex items-center gap-6">
+            <div className="flex items-center gap-6 text-gray-50">
               <img
                 src={ic_location}
                 alt="위치 아이콘"

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -130,10 +130,8 @@ export default function PostLarge({
           {children}
         </div>
       </div>
-      <div className="mt-12 rounded-xl bg-gray-10 p-20 md:mt-24 md:p-32">
-        <div className="mb-8 leading-17 font-bold md:mb-12 md:leading-20">
-          공고 설명
-        </div>
+      <div className="mt-12 flex flex-col gap-8 rounded-xl bg-gray-10 p-20 md:mt-24 md:gap-12 md:p-32">
+        <div className="leading-17 font-bold md:leading-20">공고 설명</div>
         {noticeDescription}
       </div>
     </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -30,12 +30,8 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
   } = data;
 
   const status = getStatus(startsAt, closed);
-  const isInactive = status !== 'ACTIVE';
-  const overlayText = isInactive
-    ? status === 'CLOSED'
-      ? '마감 완료'
-      : '지난 공고'
-    : '';
+  const overlayText =
+    status === 'ACTIVE' ? '' : status === 'CLOSED' ? '마감 완료' : '지난 공고';
 
   const dateTime = `${formatWorkTime({ startsAt, workhour })} (${workhour}시간)`;
 
@@ -47,17 +43,12 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
   const background = imageUrl ?? PostImg;
 
   let badgeBgColor = '';
-
-  if (isInactive) {
-    badgeBgColor = 'bg-gray-20';
-  } else {
-    if (percent >= 50) {
-      badgeBgColor = 'bg-red-40';
-    } else if (percent >= 30) {
-      badgeBgColor = 'bg-red-30';
-    } else if (percent >= 1) {
-      badgeBgColor = 'bg-red-20 ';
-    }
+  if (percent >= 50) {
+    badgeBgColor = 'bg-red-40';
+  } else if (percent >= 30) {
+    badgeBgColor = 'bg-red-30';
+  } else if (percent >= 1) {
+    badgeBgColor = 'bg-red-20 ';
   }
 
   return (
@@ -67,15 +58,13 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           className="relative h-84 w-full rounded-xl bg-cover bg-center md:h-171 lg:h-160"
           style={{ backgroundImage: `url(${background})` }}
         />
-        {isInactive && (
+        {status === 'ACTIVE' || (
           <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-[#000000]/70 text-h3 font-bold text-gray-30 md:text-h1">
             {overlayText}
           </div>
         )}
       </div>
-      <div
-        className={` ${isInactive ? 'text-gray-30' : 'text-black'} flex flex-col gap-16`}
-      >
+      <div className="flex flex-col gap-16 text-black">
         <div className="flex flex-col gap-8">
           <div
             className="truncate text-body1/20 font-bold md:text-h3/24"
@@ -83,9 +72,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           >
             {name}
           </div>
-          <div
-            className={`${isInactive ? 'text-gray-30' : 'text-gray-50'} flex flex-col gap-8 text-caption/16 font-regular md:text-body2/22`}
-          >
+          <div className="flex flex-col gap-8 text-caption/16 font-regular text-gray-50 md:text-body2/22">
             <div className="flex items-center gap-6">
               <img
                 src={ic_clock}
@@ -111,7 +98,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           <div className="truncate text-lg/23 font-bold md:text-h2/29 lg:max-w-110">
             {hourlyPay.toLocaleString()}원
           </div>
-          {isHigherPay && (
+          {isHigherPay && status === 'ACTIVE' && (
             <div
               className={`flex h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white ${badgeBgColor}`}
             >

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -120,7 +120,12 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
           </div>
         </div>
       </div>
-      <div>{noticeDescription}</div>
+      <div className="mt-12 rounded-xl bg-gray-10 p-20 md:mt-24 md:p-32">
+        <div className="mb-8 leading-17 font-bold md:mb-12 md:leading-20">
+          공고 설명
+        </div>
+        {noticeDescription}
+      </div>
     </div>
   );
 }

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -1,3 +1,157 @@
-export default function PostLarge() {
-  return;
+import formatWorkTime from '@/utils/formatWorkTime';
+import ClockRed from '@/assets/icons/clock-red.svg';
+import ClockGray from '@/assets/icons/clock-gray.svg';
+import LocationRed from '@/assets/icons/location-red.svg';
+import LocationGray from '@/assets/icons/location-gray.svg';
+import ArrowUpWhite from '@/assets/icons/arrow-up-white.svg';
+import ArrowUpGray from '@/assets/icons/arrow-up-gray.svg';
+import ArrowUpRed40 from '@/assets/icons/arrow-up-red40.svg';
+import ArrowUpRed30 from '@/assets/icons/arrow-up-red30.svg';
+import ArrowUpRed20 from '@/assets/icons/arrow-up-red20.svg';
+import PostImg from '@/assets/images/post-default.png';
+import type { NoticeDetailItem } from '@/api/noticeApi';
+
+// 상태 계산
+function getStatus(
+  startsAt: string,
+  closed: boolean,
+): 'ACTIVE' | 'CLOSED' | 'EXPIRED' {
+  const now = new Date();
+  const startDate = new Date(startsAt);
+
+  if (closed) return 'CLOSED'; // 인원 다 찼으면 마감
+  if (now >= startDate) return 'EXPIRED'; // 기간 종료되면 마감
+  return 'ACTIVE';
+}
+
+export default function PostLarge({ data }: { data: NoticeDetailItem }) {
+  const {
+    hourlyPay,
+    workhour,
+    startsAt,
+    closed,
+    shop: {
+      item: { name, address1, imageUrl, originalHourlyPay },
+    },
+  } = data;
+
+  const status = getStatus(startsAt, closed);
+  const isInactive = status !== 'ACTIVE';
+  const overlayText = isInactive
+    ? status === 'CLOSED'
+      ? '마감 완료'
+      : '지난 공고'
+    : '';
+
+  const dateTime = `${formatWorkTime({ startsAt, workhour })} (${workhour}시간)`;
+
+  const percent = Math.floor(
+    ((hourlyPay - originalHourlyPay) / originalHourlyPay) * 100,
+  );
+  const isHigherPay = percent > 0; // 이전 시급보다 높을 때만 표시
+
+  const clockIcon = isInactive ? ClockGray : ClockRed;
+  const locationIcon = isInactive ? LocationGray : LocationRed;
+
+  const background = imageUrl ?? PostImg;
+
+  let badgeBgColor = '';
+  let badgeTextColor = '';
+  let arrowIcon = '';
+
+  if (isInactive) {
+    badgeBgColor = 'bg-gray-20';
+    badgeTextColor = 'text-gray-20';
+    arrowIcon = ArrowUpGray;
+  } else {
+    if (percent >= 50) {
+      badgeBgColor = 'bg-red-40';
+      badgeTextColor = 'text-red-40';
+      arrowIcon = ArrowUpRed40;
+    } else if (percent >= 30) {
+      badgeBgColor = 'bg-red-30';
+      badgeTextColor = 'text-red-30';
+      arrowIcon = ArrowUpRed30;
+    } else if (percent >= 1) {
+      badgeBgColor = 'bg-red-20 ';
+      badgeTextColor = 'text-red-20';
+      arrowIcon = ArrowUpRed20;
+    }
+  }
+
+  return (
+    <div className="flex h-261 w-full cursor-pointer flex-col gap-12 rounded-xl border border-gray-20 bg-white p-12 md:h-359 md:gap-20 md:p-16 lg:h-348">
+      <div className="relative">
+        <div
+          className="relative h-84 w-full rounded-xl bg-cover bg-center md:h-171 lg:h-160"
+          style={{ backgroundImage: `url(${background})` }}
+        />
+        {isInactive && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-[#000000]/70 text-h3 font-bold text-gray-30 md:text-h1">
+            {overlayText}
+          </div>
+        )}
+      </div>
+      <div
+        className={` ${isInactive ? 'text-gray-30' : 'text-black'} flex flex-col gap-16`}
+      >
+        <div className="flex flex-col gap-8">
+          <div
+            className="truncate text-body1/20 font-bold md:text-h3/24"
+            title={`${name}`}
+          >
+            {name}
+          </div>
+          <div
+            className={`${isInactive ? 'text-gray-30' : 'text-gray-50'} flex flex-col gap-8 text-caption/16 font-regular md:text-body2/22`}
+          >
+            <div className="flex items-center gap-6">
+              <img
+                src={clockIcon}
+                alt="시계 아이콘"
+                className="size-16 md:size-20"
+              />
+              <span>{dateTime}</span>
+            </div>
+            <div className="flex items-center gap-6">
+              <img
+                src={locationIcon}
+                alt="위치 아이콘"
+                className="size-16 md:size-20"
+              />
+              <span>{address1}</span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="flex flex-col justify-between md:flex-row md:items-center"
+          title={`${hourlyPay.toLocaleString()}원${isHigherPay ? `: 기존 시급보다 ${percent}%` : ''}`}
+        >
+          <div className="truncate text-lg/23 font-bold md:text-h2/29 lg:max-w-110">
+            {hourlyPay.toLocaleString()}원
+          </div>
+          {isHigherPay && (
+            <>
+              {/*데스크탑, 태블릿*/}
+              <div
+                className={`hidden h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white md:flex ${badgeBgColor}`}
+              >
+                <div className="max-w-168 truncate">
+                  기존 시급보다 {percent}%
+                </div>
+                <img src={ArrowUpWhite} alt="위 화살표" className="h-20 w-20" />
+              </div>
+              {/*모바일*/}
+              <div
+                className={`flex items-center gap-2 text-caption/16 md:hidden ${badgeTextColor}`}
+              >
+                <div className="truncate">기존 시급보다 {percent}%</div>
+                <img src={arrowIcon} alt="위 화살표" className="h-16 w-16" />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -75,12 +75,16 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
             </div>
             {isHigherPay && status === 'ACTIVE' && (
               <div
-                className={`flex h-36 max-w-168 items-center justify-center gap-2 rounded-[20px] p-12 text-body2 font-bold text-white ${badgeBgColor}`}
+                className={`flex h-24 items-center justify-center gap-2 rounded-full px-8 py-4 text-caption/16 text-white md:h-36 md:p-12 md:text-body2 md:font-bold ${badgeBgColor}`}
               >
-                <div className="max-w-168 truncate">
+                <div className="max-w-122 truncate">
                   기존 시급보다 {percent}%
                 </div>
-                <img src={ic_arrow} alt="위 화살표" className="h-20 w-20" />
+                <img
+                  src={ic_arrow}
+                  alt="위 화살표"
+                  className="size-16 md:size-20"
+                />
               </div>
             )}
           </div>

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import formatWorkTime from '@/utils/formatWorkTime';
 import ic_clock from '@/assets/icons/clock-red.svg';
 import ic_location from '@/assets/icons/location-red.svg';
@@ -18,7 +19,15 @@ function getStatus(
   return 'ACTIVE';
 }
 
-export default function PostLarge({ data }: { data: NoticeDetailItem }) {
+export default function PostLarge({
+  className = '',
+  data,
+  children,
+}: {
+  className?: string;
+  data: NoticeDetailItem;
+  children?: ReactNode;
+}) {
   const {
     hourlyPay,
     workhour,
@@ -58,7 +67,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
   }
 
   return (
-    <div className="text-body2/22 font-regular md:text-body1/26">
+    <div className={`text-body2/22 font-regular md:text-body1/26 ${className}`}>
       <div className="flex min-h-356 flex-col items-stretch justify-between rounded-xl border border-gray-20 bg-white p-20 md:p-24 lg:flex-row">
         <div className="relative h-178 md:h-360 lg:h-auto lg:w-539">
           <div
@@ -118,6 +127,7 @@ export default function PostLarge({ data }: { data: NoticeDetailItem }) {
             </div>
             {shopDescription}
           </div>
+          {children}
         </div>
       </div>
       <div className="mt-12 rounded-xl bg-gray-10 p-20 md:mt-24 md:p-32">

--- a/src/components/common/PostLarge.tsx
+++ b/src/components/common/PostLarge.tsx
@@ -68,7 +68,7 @@ export default function PostLarge({
 
   return (
     <div className={`text-body2/22 font-regular md:text-body1/26 ${className}`}>
-      <div className="flex min-h-356 flex-col items-stretch justify-between rounded-xl border border-gray-20 bg-white p-20 md:p-24 lg:flex-row">
+      <div className="flex min-h-356 flex-col items-stretch justify-between rounded-xl border border-gray-20 bg-white p-19 md:p-23 lg:flex-row">
         <div className="relative h-178 md:h-360 lg:h-auto lg:w-539">
           <div
             className="h-full w-full rounded-xl bg-cover bg-center"


### PR DESCRIPTION
## 📌 변경 사항 개요

공고 상세페이지에서 사용되는 PostLarge 컴포넌트를 만들었습니다.

## 📝 상세 내용

- `Post` 컴포넌트와 유사합니다.
- `data` prop으로 `NoticeDetailItem` 형식의 데이터를 받아서 보여줍니다.
- **`children` prop으로 버튼**을 받아 위치시킵니다.
- `className` prop로 스타일을 지정할 수 있습니다.
- 너비를 지정하지 않았습니다.

## 🔗 관련 이슈

Resolves: #133 

## 🖼️ 스크린샷(선택사항)
![image](https://github.com/user-attachments/assets/3447d818-c1ac-4218-8a66-d9029d126409)
![image](https://github.com/user-attachments/assets/a3c1fe0a-aa9f-46c9-a0b2-8641d02394c2)
![image](https://github.com/user-attachments/assets/3780fa3a-eaec-44bb-b5e7-91496f9dc907)

![image](https://github.com/user-attachments/assets/4da978bd-acbf-4d44-bea3-183d61722835)
![image](https://github.com/user-attachments/assets/7147e466-b0ad-4249-ac37-69dc5716cfc1)
![image](https://github.com/user-attachments/assets/b40eaf89-bd45-4ae7-a770-3ed782ab8d7e)

## 💡 참고 사항

- 공고 설명이 없을 경우의 처리를 따로 하지는 않았습니다.
- 버튼의 스타일과 로직이 다양하여 어떻게 처리를 할까하다 Button을 children으로 받게 구현했습니다.
- 구현 이미지는 mockdata를 활용했습니다.