### PR TITLE
🐛 fix: 공고 param 변수 이름 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
       <Routes>
         {/* 공통 페이지 */}
         <Route path="/" element={<NoticeList />} />
-        <Route path=":shopId/:userId" element={<Notice />} />
+        <Route path=":shopId/:noticeId" element={<Notice />} />
         <Route path="login" element={<Login />} />
         <Route path="signup" element={<Signup />} />
 
@@ -32,7 +32,7 @@ export default function App() {
           </Route>
           <Route path="post">
             <Route index element={<StoreForm />} />
-            <Route path=":shopId/:userId" element={<StorePost />} />
+            <Route path=":shopId/:noticeId" element={<StorePost />} />
           </Route>
         </Route>
 


### PR DESCRIPTION
## 📌 변경 사항 개요

공고 상세 페이지들에 대한 params 변수 이름을 변경했습니다.

## 📝 상세 내용

공고 상세 페이지에서 param 변수 이름을 `userId` > `noticeId`로 변경했습니다.

## 🔗 관련 이슈

Resolves: #138 

## 🖼️ 스크린샷(선택사항)

## 💡 참고 사항