### PR TITLE
✨ feat: 사장님 공고 상세(StorePost) 페이지 컴포넌트 구현

### DIFF
--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -11,9 +11,13 @@ export default function StorePost() {
   const { shopId, noticeId } = useParams();
   const [notice, setNotice] = useState<NoticeDetailItem>();
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-  const [modalType, setModalType] = useState<'notice' | null>(null);
+  const [modalType, setModalType] = useState<'notice' | 'login' | null>(null);
 
   useEffect(() => {
+    if (!localStorage.getItem('userId')) {
+      setModalType('login');
+    }
+
     if (!shopId || !noticeId) return;
 
     (async () => {

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -18,8 +18,21 @@ export default function StorePost() {
 
   return (
     <div className="flex min-h-[calc(100vh-108px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh_-_70px)]">
-      <section className="w-full px-12 py-40 md:px-32 md:py-60"></section>
-      <section className="w-full flex-1 px-12 pt-40 pb-80 md:px-32 md:py-60"></section>
+      <section className="w-full px-12 py-40 md:px-32 md:py-60">
+        <div>
+          <div className="mb-8 text-body2/17 font-bold text-primary md:text-body1/20">
+            식당
+          </div>
+          <h1 className="text-h3/24 font-bold text-black md:text-h1/34 md:text-[#000]">
+            {notice?.shop.item.name}아
+          </h1>
+        </div>
+      </section>
+      <section className="w-full flex-1 px-12 pt-40 pb-80 md:px-32 md:py-60">
+        <h1 className="text-h3/24 font-bold text-black md:text-h1/42 md:text-[#000]">
+          신청자 목록
+        </h1>
+      </section>
       <Footer />
     </div>
   );

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -21,6 +21,7 @@ export default function StorePost() {
   useEffect(() => {
     if (!localStorage.getItem('userId')) {
       setModalType('login');
+      return;
     }
 
     if (!shopId || !noticeId) return;

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -7,6 +7,7 @@ import PostLarge from '@/components/common/PostLarge';
 export default function StorePost() {
   const { shopId, noticeId } = useParams();
   const [notice, setNotice] = useState<NoticeDetailItem>();
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
   useEffect(() => {
     if (!shopId || !noticeId) return;
@@ -16,6 +17,15 @@ export default function StorePost() {
       setNotice(item);
     })();
   }, [shopId, noticeId]);
+
+  // 반응형
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   return (
     <div className="flex min-h-[calc(100vh-108px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh_-_70px)]">

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { getShopNotice, type NoticeDetailItem } from '@/api/noticeApi';
 import Footer from '@/components/layout/Footer';
 import PostLarge from '@/components/common/PostLarge';
+import Button from '@/components/common/Button';
 
 export default function StorePost() {
   const { shopId, noticeId } = useParams();
@@ -39,7 +40,13 @@ export default function StorePost() {
               {notice?.shop.item.name}
             </h1>
           </div>
-          {notice && <PostLarge data={notice} />}
+          {notice && (
+            <PostLarge data={notice}>
+              <Button size={isMobile ? 'medium' : 'large'} solid={false}>
+                공고 편집하기
+              </Button>
+            </PostLarge>
+          )}
         </div>
       </section>
       <section className="w-full flex-1 px-12 pt-40 pb-80 md:px-32 md:py-60">

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -5,18 +5,24 @@ import Footer from '@/components/layout/Footer';
 import PostLarge from '@/components/common/PostLarge';
 import Button from '@/components/common/Button';
 import Table from '@/components/common/table/Table';
+import Modal from '@/components/common/Modal';
 
 export default function StorePost() {
   const { shopId, noticeId } = useParams();
   const [notice, setNotice] = useState<NoticeDetailItem>();
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     if (!shopId || !noticeId) return;
 
     (async () => {
-      const { item } = await getShopNotice(shopId, noticeId);
-      setNotice(item);
+      try {
+        const { item } = await getShopNotice(shopId, noticeId);
+        setNotice(item);
+      } catch {
+        setIsModalOpen(true);
+      }
     })();
   }, [shopId, noticeId]);
 
@@ -60,6 +66,7 @@ export default function StorePost() {
           )}
         </div>
       </section>
+      {isModalOpen && <Modal>존재하지 않는 공고입니다.</Modal>}
       <Footer />
     </div>
   );

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -11,7 +11,7 @@ export default function StorePost() {
   const { shopId, noticeId } = useParams();
   const [notice, setNotice] = useState<NoticeDetailItem>();
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalType, setModalType] = useState<'notice' | null>(null);
 
   useEffect(() => {
     if (!shopId || !noticeId) return;
@@ -21,7 +21,7 @@ export default function StorePost() {
         const { item } = await getShopNotice(shopId, noticeId);
         setNotice(item);
       } catch {
-        setIsModalOpen(true);
+        setModalType('notice');
       }
     })();
   }, [shopId, noticeId]);
@@ -66,7 +66,7 @@ export default function StorePost() {
           )}
         </div>
       </section>
-      {isModalOpen && <Modal>존재하지 않는 공고입니다.</Modal>}
+      {modalType && <Modal>존재하지 않는 공고입니다.</Modal>}
       <Footer />
     </div>
   );

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -1,6 +1,21 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getShopNotice, type NoticeDetailItem } from '@/api/noticeApi';
 import Footer from '@/components/layout/Footer';
 
 export default function StorePost() {
+  const { shopId, noticeId } = useParams();
+  const [notice, setNotice] = useState<NoticeDetailItem>();
+
+  useEffect(() => {
+    if (!shopId || !noticeId) return;
+
+    (async () => {
+      const { item } = await getShopNotice(shopId, noticeId);
+      setNotice(item);
+    })();
+  }, [shopId, noticeId]);
+
   return (
     <div className="flex min-h-[calc(100vh-108px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh_-_70px)]">
       <section className="w-full px-12 py-40 md:px-32 md:py-60"></section>

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -4,6 +4,7 @@ import { getShopNotice, type NoticeDetailItem } from '@/api/noticeApi';
 import Footer from '@/components/layout/Footer';
 import PostLarge from '@/components/common/PostLarge';
 import Button from '@/components/common/Button';
+import Table from '@/components/common/table/Table';
 
 export default function StorePost() {
   const { shopId, noticeId } = useParams();
@@ -50,9 +51,14 @@ export default function StorePost() {
         </div>
       </section>
       <section className="w-full flex-1 px-12 pt-40 pb-80 md:px-32 md:py-60">
-        <h1 className="text-h3/24 font-bold text-black md:text-h1/42 md:text-[#000]">
-          신청자 목록
-        </h1>
+        <div className="mx-auto flex max-w-964 flex-col gap-16 md:gap-32">
+          <h1 className="text-h3/24 font-bold text-black md:text-h1/42 md:text-[#000]">
+            신청자 목록
+          </h1>
+          {shopId && noticeId && (
+            <Table mode="notice" shopId={shopId} noticeId={noticeId} />
+          )}
+        </div>
       </section>
       <Footer />
     </div>

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { getShopNotice, type NoticeDetailItem } from '@/api/noticeApi';
 import Footer from '@/components/layout/Footer';
 import PostLarge from '@/components/common/PostLarge';
@@ -13,10 +13,16 @@ const MODAL_MESSAGE = {
 };
 
 export default function StorePost() {
+  const navigate = useNavigate();
   const { shopId, noticeId } = useParams();
   const [notice, setNotice] = useState<NoticeDetailItem>();
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   const [modalType, setModalType] = useState<'notice' | 'login' | null>(null);
+
+  const handleClose = () => {
+    if (modalType === 'notice') navigate('/owner/store');
+    else if (modalType === 'login') navigate('/login');
+  };
 
   useEffect(() => {
     if (!localStorage.getItem('userId')) {
@@ -76,7 +82,11 @@ export default function StorePost() {
           )}
         </div>
       </section>
-      {modalType && <Modal>{MODAL_MESSAGE[modalType]}</Modal>}
+      {modalType && (
+        <Modal onClose={handleClose} onButtonClick={handleClose}>
+          {MODAL_MESSAGE[modalType]}
+        </Modal>
+      )}
       <Footer />
     </div>
   );

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { getShopNotice, type NoticeDetailItem } from '@/api/noticeApi';
 import Footer from '@/components/layout/Footer';
+import PostLarge from '@/components/common/PostLarge';
 
 export default function StorePost() {
   const { shopId, noticeId } = useParams();
@@ -19,13 +20,16 @@ export default function StorePost() {
   return (
     <div className="flex min-h-[calc(100vh-108px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh_-_70px)]">
       <section className="w-full px-12 py-40 md:px-32 md:py-60">
-        <div>
-          <div className="mb-8 text-body2/17 font-bold text-primary md:text-body1/20">
-            식당
+        <div className="mx-auto flex max-w-964 flex-col gap-16 md:gap-24">
+          <div>
+            <div className="mb-8 text-body2/17 font-bold text-primary md:text-body1/20">
+              식당
+            </div>
+            <h1 className="text-h3/24 font-bold text-black md:text-h1/34 md:text-[#000]">
+              {notice?.shop.item.name}
+            </h1>
           </div>
-          <h1 className="text-h3/24 font-bold text-black md:text-h1/34 md:text-[#000]">
-            {notice?.shop.item.name}
-          </h1>
+          {notice && <PostLarge data={notice} />}
         </div>
       </section>
       <section className="w-full flex-1 px-12 pt-40 pb-80 md:px-32 md:py-60">

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -24,7 +24,7 @@ export default function StorePost() {
             식당
           </div>
           <h1 className="text-h3/24 font-bold text-black md:text-h1/34 md:text-[#000]">
-            {notice?.shop.item.name}아
+            {notice?.shop.item.name}
           </h1>
         </div>
       </section>

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -1,3 +1,11 @@
+import Footer from '@/components/layout/Footer';
+
 export default function StorePost() {
-  return <div>내 가게 공고 상세 (사장님)</div>;
+  return (
+    <div className="flex min-h-[calc(100vh-108px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh_-_70px)]">
+      <section className="w-full px-12 py-40 md:px-32 md:py-60"></section>
+      <section className="w-full flex-1 px-12 pt-40 pb-80 md:px-32 md:py-60"></section>
+      <Footer />
+    </div>
+  );
 }

--- a/src/pages/store/StorePost.tsx
+++ b/src/pages/store/StorePost.tsx
@@ -7,6 +7,11 @@ import Button from '@/components/common/Button';
 import Table from '@/components/common/table/Table';
 import Modal from '@/components/common/Modal';
 
+const MODAL_MESSAGE = {
+  notice: '존재하지 않는 공고입니다.',
+  login: '로그인이 필요합니다.',
+};
+
 export default function StorePost() {
   const { shopId, noticeId } = useParams();
   const [notice, setNotice] = useState<NoticeDetailItem>();
@@ -70,7 +75,7 @@ export default function StorePost() {
           )}
         </div>
       </section>
-      {modalType && <Modal>존재하지 않는 공고입니다.</Modal>}
+      {modalType && <Modal>{MODAL_MESSAGE[modalType]}</Modal>}
       <Footer />
     </div>
   );


### PR DESCRIPTION
## 📌 변경 사항 개요

사장님 공고 상세(StorePost) 페이지를 구현했습니다.

## 📝 상세 내용

- 로그인 상태가 아니라면 (localStorage에 userId가 없으면) 로그인이 필요합니다 모달창을 띄웁니다. 로그인 페이지 `/login`로 보냅니다.
- 경로의 params에서 shopId/noticeId 가 존재하는 아이디가 아니라면 존재하는 공고가 아닙니다 모달창을 띄웁니다. 가게 페이지 `/owner/store`로 보냅니다.

## 🔗 관련 이슈

Resolves: #113 

## 🖼️ 스크린샷(선택사항)


https://github.com/user-attachments/assets/a0f5d411-ca97-4176-9b9a-7964136483b7

![image](https://github.com/user-attachments/assets/44016fd5-cb48-4a30-9650-65f7d5d34adf)
![image](https://github.com/user-attachments/assets/cdfa79e2-1362-4797-8fb4-2e63c9807108)
![image](https://github.com/user-attachments/assets/9696a79a-74c7-4efa-8cf3-34989f0f6f80)

## 💡 참고 사항

- 공고 편집 경로가 존재하지 않아 공고 편집하기 버튼은 동작하지 않습니다. 