### PR TITLE
✨ feat: 공고 상세 페이지 구현

### DIFF
--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -11,6 +11,7 @@ import ArrowUpRed30 from '@/assets/icons/arrow-up-red30.svg';
 import ArrowUpRed20 from '@/assets/icons/arrow-up-red20.svg';
 import PostImg from '@/assets/images/post-default.png';
 import type { NoticeShopItem } from '@/api/noticeApi';
+import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 
 // 상태 계산
 function getStatus(
@@ -38,6 +39,7 @@ export default function Post({ data }: { data: NoticeShopItem }) {
   } = data;
   const navigate = useNavigate();
   const location = useLocation();
+  const { addRecentlyViewed } = useRecentlyViewed();
   const status = getStatus(startsAt, closed);
   const isInactive = status !== 'ACTIVE';
   const overlayText = isInactive
@@ -83,6 +85,8 @@ export default function Post({ data }: { data: NoticeShopItem }) {
   }
 
   const handleClick = () => {
+    addRecentlyViewed(data);
+
     const isOwnerPage = location.pathname.startsWith('/owner');
 
     const path = isOwnerPage

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+import type { NoticeShopItem } from '@/api/noticeApi';
+
+const loadFromStorage = (): NoticeShopItem[] => {
+  try {
+    const storedData = localStorage.getItem('recentlyViewedPosts');
+    return storedData ? JSON.parse(storedData) : [];
+  } catch (error) {
+    console.error(
+      'Failed to parse recently viewed posts from localStorage',
+      error,
+    );
+    return [];
+  }
+};
+
+const saveToStorage = (posts: NoticeShopItem[]) => {
+  try {
+    localStorage.setItem('recentlyViewedPosts', JSON.stringify(posts));
+  } catch (error) {
+    console.error(
+      'Failed to save recently viewed posts to localStorage',
+      error,
+    );
+  }
+};
+
+export function useRecentlyViewed() {
+  const [recentlyViewed, setRecentlyViewed] = useState<NoticeShopItem[]>([]);
+
+  useEffect(() => {
+    setRecentlyViewed(loadFromStorage());
+  }, []);
+
+  const addRecentlyViewed = (post: NoticeShopItem) => {
+    const currentPosts = loadFromStorage();
+    const filteredPosts = currentPosts.filter((item) => item.id !== post.id);
+    const newPosts = [post, ...filteredPosts];
+    const limitedPosts = newPosts.slice(0, 6);
+
+    saveToStorage(limitedPosts);
+    setRecentlyViewed(limitedPosts);
+  };
+
+  return { recentlyViewed, addRecentlyViewed };
+}

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import type { NoticeShopItem } from '@/api/noticeApi';
 
 const loadFromStorage = (): NoticeShopItem[] => {
@@ -42,5 +42,9 @@ export function useRecentlyViewed() {
     setRecentlyViewed(limitedPosts);
   };
 
-  return { recentlyViewed, addRecentlyViewed };
+  const refreshRecentlyViewed = useCallback(() => {
+    setRecentlyViewed(loadFromStorage());
+  }, []);
+
+  return { recentlyViewed, addRecentlyViewed, refreshRecentlyViewed };
 }

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -9,7 +9,7 @@ export function useToast(duration: number = 2000) {
     isVisible: false,
   });
 
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // 토스트를 보여주는 함수
   const showToast = useCallback(

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,37 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+export function useToast(duration: number = 2000) {
+  const [toast, setToast] = useState<{
+    message: string;
+    isVisible: boolean;
+  }>({
+    message: '',
+    isVisible: false,
+  });
+
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // 토스트를 보여주는 함수
+  const showToast = useCallback(
+    (message: string) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      setToast({ message, isVisible: true });
+      timerRef.current = setTimeout(() => {
+        setToast({ message, isVisible: false });
+      }, duration);
+    },
+    [duration],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return { toast, showToast };
+}

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -1,3 +1,32 @@
+import Post from '@/components/common/Post';
+import Footer from '@/components/layout/Footer';
+import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
+
 export default function Notice() {
-  return <div>공고 상세</div>;
+  const { recentlyViewed } = useRecentlyViewed();
+
+  return (
+    <div className="flex min-h-[calc(100vh-102px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh-70px)]">
+      <div className="h-500 bg-gray-50">식당정보</div>
+      <div className="flex-1">
+        <div className="mx-12 flex flex-col gap-16 pt-40 pb-80 md:mx-32 md:gap-24 md:pt-60 md:pb-120 lg:mx-auto lg:w-964">
+          <h1 className="text-h3 font-bold md:text-h1 md:font-bold">
+            최근에 본 공고
+          </h1>
+          {recentlyViewed.length === 0 ? (
+            <div className="flex h-120 items-center justify-center rounded-lg bg-gray-10 text-gray-40">
+              최근에 본 공고가 없습니다.
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-x-8 gap-y-16 md:gap-x-14 md:gap-y-32 lg:grid-cols-3">
+              {recentlyViewed.map((postData) => (
+                <Post key={postData.id} data={postData} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
 }

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -5,9 +5,11 @@ import Footer from '@/components/layout/Footer';
 import PostLarge from '@/components/common/PostLarge';
 import Modal from '@/components/common/Modal';
 import Button from '@/components/common/Button';
+import Toast from '@/components/common/Toast';
+import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
+import { useToast } from '@/hooks/useToast';
 import { getUser } from '@/api/userApi';
 import { getShopNotice, type NoticeDetailItem } from '@/api/noticeApi';
-import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 import {
   getUserApplications,
   postNoticeApplications,
@@ -31,6 +33,7 @@ export default function Notice() {
   const navigate = useNavigate();
   const { shopId, noticeId } = useParams();
   const { recentlyViewed, refreshRecentlyViewed } = useRecentlyViewed();
+  const { toast, showToast } = useToast();
   const [noticeData, setNoticeData] = useState<NoticeDetailItem | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [applicationInfo, setApplicationInfo] = useState<ApplicationInfoState>({
@@ -126,6 +129,7 @@ export default function Notice() {
           isApplied: true,
           applicationId: newApplicationId,
         });
+        showToast('신청 완료!');
       } else {
         setModal({
           isOpen: true,
@@ -157,6 +161,7 @@ export default function Notice() {
         isOpen: false,
         message: '',
       });
+      showToast('취소했어요');
     } catch (error) {
       setModal({
         isOpen: true,
@@ -265,6 +270,15 @@ export default function Notice() {
                 {modal.message}
               </Modal>
             )}
+            <div
+              className={`fixed bottom-100 left-1/2 -translate-x-1/2 transform transition-all duration-300 ease-out ${
+                toast.isVisible
+                  ? 'translate-y-0 opacity-100'
+                  : 'pointer-events-none translate-y-10 opacity-0'
+              } `}
+            >
+              <Toast>{toast.message}</Toast>
+            </div>
           </div>
         )
       )}

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -50,6 +50,9 @@ export default function Notice() {
     const userId = localStorage.getItem('userId');
     const fetchNotice = async () => {
       setIsLoading(true);
+      // notice 컴포넌트 재사용 문제 해결을 위한 데이터 초기화
+      setNoticeData(null);
+      setApplicationInfo({ isApplied: false, applicationId: null });
       try {
         const data = await getShopNotice(shopId, noticeId);
         setNoticeData(data.item);
@@ -67,6 +70,12 @@ export default function Notice() {
             setApplicationInfo({
               isApplied: true,
               applicationId: appliedApplication.item.id,
+            });
+          } else {
+            // 컴포넌트 재사용 문제 해결을 위한 데이터 초기화
+            setApplicationInfo({
+              isApplied: false,
+              applicationId: null,
             });
           }
         }

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -1,32 +1,97 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import Post from '@/components/common/Post';
 import Footer from '@/components/layout/Footer';
+import PostLarge from '@/components/common/PostLarge';
+import Modal from '@/components/common/Modal';
+import Button from '@/components/common/Button';
+import { getShopNotice } from '@/api/noticeApi';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 
 export default function Notice() {
+  const { shopId, userId } = useParams();
   const { recentlyViewed } = useRecentlyViewed();
+  const [noticeData, setNoticeData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [modal, setModal] = useState({
+    isOpen: false,
+    message: '',
+  });
+  const [buttonSize, setButtonSize] = useState<'large' | 'medium'>('medium');
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setButtonSize('large');
+      } else {
+        setButtonSize('medium');
+      }
+    };
 
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    const fetchNotice = async () => {
+      try {
+        const data = await getShopNotice(shopId, userId);
+        setNoticeData(data.item);
+      } catch (error) {
+        setModal({
+          isOpen: true,
+          message: (error as Error).message,
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchNotice();
+  }, [shopId, userId]);
   return (
-    <div className="flex min-h-[calc(100vh-102px)] flex-col justify-between bg-gray-5 md:min-h-[calc(100vh-70px)]">
-      <div className="h-500 bg-gray-50">식당정보</div>
-      <div className="flex-1">
-        <div className="mx-12 flex flex-col gap-16 pt-40 pb-80 md:mx-32 md:gap-24 md:pt-60 md:pb-120 lg:mx-auto lg:w-964">
-          <h1 className="text-h3 font-bold md:text-h1 md:font-bold">
-            최근에 본 공고
-          </h1>
-          {recentlyViewed.length === 0 ? (
-            <div className="flex h-120 items-center justify-center rounded-lg bg-gray-10 text-gray-40">
-              최근에 본 공고가 없습니다.
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 gap-x-8 gap-y-16 md:gap-x-14 md:gap-y-32 lg:grid-cols-3">
-              {recentlyViewed.map((postData) => (
-                <Post key={postData.id} data={postData} />
-              ))}
-            </div>
-          )}
+    <>
+      {isLoading ? (
+        <div className="flex min-h-[calc(100vh-102px)] items-center justify-center md:min-h-[calc(100vh-70px)]">
+          <div className="size-100 animate-spin rounded-full border-8 border-gray-200 border-t-primary" />
         </div>
-      </div>
-      <Footer />
-    </div>
+      ) : (
+        <div className="flex min-h-[calc(100vh-102px)] flex-col justify-between md:min-h-[calc(100vh-70px)]">
+          <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
+            <div className="flex flex-col gap-8">
+              <p className="text-body2 font-bold text-primary md:text-body1">
+                식당
+              </p>
+              <h1 className="text-h3 font-bold md:text-h1">
+                {noticeData.shop.item.name}
+              </h1>
+            </div>
+            <PostLarge data={noticeData}>
+              <Button size={buttonSize}>신청하기</Button>
+            </PostLarge>
+          </div>
+          <div className="flex-1">
+            <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
+              <h1 className="text-h3 font-bold md:text-h1 md:font-bold">
+                최근에 본 공고
+              </h1>
+              {recentlyViewed.length === 0 ? (
+                <div className="flex h-120 items-center justify-center rounded-lg bg-gray-10 text-gray-40">
+                  최근에 본 공고가 없습니다.
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-x-8 gap-y-16 md:gap-x-14 md:gap-y-32 lg:grid-cols-3">
+                  {recentlyViewed.map((postData) => (
+                    <Post key={postData.id} data={postData} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <Footer />
+          {modal.isOpen && <Modal>{modal.message}</Modal>}
+        </div>
+      )}
+    </>
   );
 }

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -1,23 +1,36 @@
-import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import Post from '@/components/common/Post';
 import Footer from '@/components/layout/Footer';
 import PostLarge from '@/components/common/PostLarge';
 import Modal from '@/components/common/Modal';
 import Button from '@/components/common/Button';
+import { getUser } from '@/api/userApi';
 import { getShopNotice } from '@/api/noticeApi';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
+import {
+  getUserApplications,
+  postNoticeApplications,
+  putNoticeApplications,
+} from '@/api/applicationApi';
 
 export default function Notice() {
-  const { shopId, userId } = useParams();
+  const navigate = useNavigate();
+  const { shopId, noticeId } = useParams();
   const { recentlyViewed } = useRecentlyViewed();
   const [noticeData, setNoticeData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [applicationInfo, setApplicationInfo] = useState({
+    isApplied: false,
+    applicationId: null,
+  });
   const [modal, setModal] = useState({
     isOpen: false,
     message: '',
+    type: '',
   });
   const [buttonSize, setButtonSize] = useState<'large' | 'medium'>('medium');
+
   useEffect(() => {
     const handleResize = () => {
       if (window.innerWidth >= 768) {
@@ -34,21 +47,141 @@ export default function Notice() {
   }, []);
 
   useEffect(() => {
+    const userId = localStorage.getItem('userId');
     const fetchNotice = async () => {
+      setIsLoading(true);
       try {
-        const data = await getShopNotice(shopId, userId);
+        const data = await getShopNotice(shopId, noticeId);
         setNoticeData(data.item);
+        if (userId) {
+          const applicationsResult = await getUserApplications(userId);
+          const userApplications = applicationsResult.items;
+
+          const appliedApplication = userApplications.find(
+            (app) =>
+              app.item.notice.item.id === noticeId &&
+              app.item.status !== 'canceled',
+          );
+
+          if (appliedApplication) {
+            setApplicationInfo({
+              isApplied: true,
+              applicationId: appliedApplication.item.id,
+            });
+          }
+        }
       } catch (error) {
         setModal({
           isOpen: true,
           message: (error as Error).message,
+          type: 'alert',
         });
       } finally {
         setIsLoading(false);
       }
     };
     fetchNotice();
-  }, [shopId, userId]);
+  }, [shopId, noticeId]);
+
+  // 신청하기 버튼 클릭
+  const handleApply = async () => {
+    try {
+      const userId = localStorage.getItem('userId');
+      const userInfo = await getUser(userId);
+      if (userInfo.item.name) {
+        const result = await postNoticeApplications(shopId, noticeId);
+        const newApplicationId = result.item.id;
+        setApplicationInfo({
+          isApplied: true,
+          applicationId: newApplicationId,
+        });
+      } else {
+        setModal({
+          isOpen: true,
+          message: '내 프로필을 먼저 등록해 주세요.',
+          type: 'confirm',
+        });
+      }
+    } catch (error) {
+      setModal({
+        isOpen: true,
+        message: (error as Error).message,
+        type: 'alert',
+      });
+    }
+  };
+
+  // 신청 취소
+  const handleConfirmCancel = async () => {
+    if (!applicationInfo.applicationId) return;
+    try {
+      await putNoticeApplications(
+        shopId,
+        noticeId,
+        applicationInfo.applicationId,
+        { status: 'canceled' },
+      );
+      setApplicationInfo({ isApplied: false, applicationId: null });
+      setModal({
+        isOpen: false,
+        message: '',
+        type: '',
+      });
+    } catch (error) {
+      setModal({
+        isOpen: true,
+        message: (error as Error).message,
+        type: 'alert',
+      });
+    }
+  };
+
+  // 취소하기 버튼 클릭
+  const handleCancelClick = () => {
+    setModal({
+      isOpen: true,
+      message: '신청을 취소하시겠어요?',
+      type: 'action',
+    });
+  };
+
+  // 버튼 렌더링 로직
+  const renderApplyButton = () => {
+    if (noticeData.closed) {
+      return (
+        <Button size={buttonSize} disabled>
+          신청 불가
+        </Button>
+      );
+    }
+
+    if (applicationInfo.isApplied) {
+      return (
+        <Button size={buttonSize} solid={false} onClick={handleCancelClick}>
+          취소하기
+        </Button>
+      );
+    }
+
+    return (
+      <Button size={buttonSize} onClick={handleApply}>
+        신청하기
+      </Button>
+    );
+  };
+
+  const handleModalClick = useCallback(() => {
+    if (modal.message.includes('로그인')) {
+      setModal({ isOpen: false, message: '', type: '' });
+      navigate('/login');
+    } else if (modal.message.includes('프로필')) {
+      setModal({ isOpen: false, message: '', type: '' });
+      navigate('/profile');
+    } else {
+      setModal({ isOpen: false, message: '' });
+    }
+  }, [modal.message, navigate]);
+
   return (
     <>
       {isLoading ? (
@@ -56,41 +189,51 @@ export default function Notice() {
           <div className="size-100 animate-spin rounded-full border-8 border-gray-200 border-t-primary" />
         </div>
       ) : (
-        <div className="flex min-h-[calc(100vh-102px)] flex-col justify-between md:min-h-[calc(100vh-70px)]">
-          <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
-            <div className="flex flex-col gap-8">
-              <p className="text-body2 font-bold text-primary md:text-body1">
-                식당
-              </p>
-              <h1 className="text-h3 font-bold md:text-h1">
-                {noticeData.shop.item.name}
-              </h1>
-            </div>
-            <PostLarge data={noticeData}>
-              <Button size={buttonSize}>신청하기</Button>
-            </PostLarge>
-          </div>
-          <div className="flex-1">
+        noticeData && (
+          <div className="flex min-h-[calc(100vh-102px)] flex-col justify-between md:min-h-[calc(100vh-70px)]">
             <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
-              <h1 className="text-h3 font-bold md:text-h1 md:font-bold">
-                최근에 본 공고
-              </h1>
-              {recentlyViewed.length === 0 ? (
-                <div className="flex h-120 items-center justify-center rounded-lg bg-gray-10 text-gray-40">
-                  최근에 본 공고가 없습니다.
-                </div>
-              ) : (
-                <div className="grid grid-cols-2 gap-x-8 gap-y-16 md:gap-x-14 md:gap-y-32 lg:grid-cols-3">
-                  {recentlyViewed.map((postData) => (
-                    <Post key={postData.id} data={postData} />
-                  ))}
-                </div>
-              )}
+              <div className="flex flex-col gap-8">
+                <p className="text-body2 font-bold text-primary md:text-body1">
+                  식당
+                </p>
+                <h1 className="text-h3 font-bold md:text-h1">
+                  {noticeData.shop.item.name}
+                </h1>
+              </div>
+              <PostLarge data={noticeData}>{renderApplyButton()}</PostLarge>
             </div>
+            <div className="flex-1">
+              <div className="mx-12 flex flex-col gap-16 py-40 md:mx-32 md:gap-24 md:py-60 lg:mx-auto lg:w-964">
+                <h1 className="text-h3 font-bold md:text-h1 md:font-bold">
+                  최근에 본 공고
+                </h1>
+                {recentlyViewed.length === 0 ? (
+                  <div className="flex h-120 items-center justify-center rounded-lg bg-gray-10 text-gray-40">
+                    최근에 본 공고가 없습니다.
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-2 gap-x-8 gap-y-16 md:gap-x-14 md:gap-y-32 lg:grid-cols-3">
+                    {recentlyViewed.map((postData) => (
+                      <Post key={postData.id} data={postData} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+            <Footer />
+            {modal.isOpen && (
+              <Modal
+                option={modal.type}
+                onButtonClick={handleModalClick}
+                onClose={handleModalClick}
+                yesButtonContent="예"
+                onYesButtonClick={handleConfirmCancel}
+              >
+                {modal.message}
+              </Modal>
+            )}
           </div>
-          <Footer />
-          {modal.isOpen && <Modal>{modal.message}</Modal>}
-        </div>
+        )
       )}
     </>
   );


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
공고 상세 페이지를 구현했습니다.
최근 공고 6개를 보여주는 기능을 수행할 `useRecentlyViewed` hook을 추가했습니다.
toast를 띄우기 위한 `useToast` hook을 추가했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
최근 본 공고들은 localStorage에 6개까지 저장하도록 구현했습니다.
각 상황에 맞는 버튼을 구현했습니다.

### 요구사항
- [x] 로고 버튼을 클릭하면 공고 리스트 페이지로 이동하세요.
- [x] '신청하기' 버튼을 누르면, 프로필 등록이 되어있지 않으면 ”내 프로필을 먼저 등록해 주세요.” alert 창이 나타납니다. '확인' 버튼을 누르면 프로필 등록 페이지로 이동하세요.
- [x] '신청하기' 버튼을 누르면, 프로필 등록이 되어있으면 신청이 완료됩니다.
- [x] 이미 신청한 공고에서 '취소하기' 버튼을 클릭하면, “신청을 취소하시겠어요?” alert 창이 나타납니다. '취소하기' 버튼을 누르면 지원이 취소되고 '취소하기' 버튼이 '신청하기' 버튼으로 바뀌게 하세요.
- [x] 최근에 본 공고:
    - [x] 최신 순으로 최대 6개까지 보이게 하세요.
    - [x] 6개를 초과할 경우, 가장 오래된 공고는 보이지 않게 하세요.
    - [x] 최근에 본 공고를 위한 별도 API는 없으니, 브라우저 저장소를 활용하세요.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #135 
## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
(2배속)

https://github.com/user-attachments/assets/b8c2fcf8-c326-411e-b821-5a10d1dca090

## 💡 참고 사항
- 테이블 컴포넌트 잘 작동하는 것 같습니다. (테이블 내 공고 클릭 시 해당 공고로 이동해도 좋을 것 같습니다~)