### PR TITLE
🐛 fix: Post 컴포넌트 내 div 태그를 link태그로 수정

### DIFF
--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import formatWorkTime from '@/utils/formatWorkTime';
 import ClockRed from '@/assets/icons/clock-red.svg';
 import ClockGray from '@/assets/icons/clock-gray.svg';
@@ -37,7 +37,6 @@ export default function Post({ data }: { data: NoticeShopItem }) {
       item: { id: shopId, name, address1, imageUrl, originalHourlyPay },
     },
   } = data;
-  const navigate = useNavigate();
   const location = useLocation();
   const { addRecentlyViewed } = useRecentlyViewed();
   const status = getStatus(startsAt, closed);

--- a/src/components/common/Post.tsx
+++ b/src/components/common/Post.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
 import formatWorkTime from '@/utils/formatWorkTime';
 import ClockRed from '@/assets/icons/clock-red.svg';
 import ClockGray from '@/assets/icons/clock-gray.svg';
@@ -84,20 +84,15 @@ export default function Post({ data }: { data: NoticeShopItem }) {
     }
   }
 
-  const handleClick = () => {
-    addRecentlyViewed(data);
+  const isOwnerPage = location.pathname.startsWith('/owner');
+  const linkPath = isOwnerPage
+    ? `/owner/post/${shopId}/${noticeId}`
+    : `/${shopId}/${noticeId}`;
 
-    const isOwnerPage = location.pathname.startsWith('/owner');
-
-    const path = isOwnerPage
-      ? `/owner/post/${shopId}/${noticeId}`
-      : `/${shopId}/${noticeId}`;
-
-    navigate(path);
-  };
   return (
-    <button
-      onClick={handleClick}
+    <Link
+      to={linkPath}
+      onClick={() => addRecentlyViewed(data)}
       className="flex h-261 w-full cursor-pointer flex-col gap-12 rounded-xl border border-gray-20 bg-white p-12 md:h-359 md:gap-20 md:p-16 lg:h-348"
     >
       <div className="relative">
@@ -171,6 +166,6 @@ export default function Post({ data }: { data: NoticeShopItem }) {
           )}
         </div>
       </div>
-    </button>
+    </Link>
   );
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
Post 컴포넌트 내에서 클릭시 페이지 이동하는 기능이 있으므로 div를 link로 변경하였습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
최상위 div태그를 Link로 변경하고, 경로 이동 관련 기능은 to속성에 추가하였습니다.
최근 본 공고 저장 기능은 onClick에 유지시켰습니다,

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #145
## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항