### PR TITLE
🐛 fix: 검색 페이지 내에서 푸터가 뜨는 스타일 오류 수정

### DIFF
--- a/src/pages/notice/NoticeList.tsx
+++ b/src/pages/notice/NoticeList.tsx
@@ -182,7 +182,7 @@ export default function NoticeList({ search = '' }: { search?: string }) {
           {error}
         </Modal>
       )}
-      <main>
+      <main className="flex min-h-[calc(100vh-102px)] flex-col justify-between md:min-h-[calc(100vh-70px)]">
         {/* 맞춤 공고 */}
         {!search && (
           <article className="bg-red-10 py-40 pl-12 md:py-60 md:pl-32 lg:px-0">
@@ -205,7 +205,7 @@ export default function NoticeList({ search = '' }: { search?: string }) {
         )}
 
         {/* 전체 공고 */}
-        <article className="px-12 pt-40 pb-68 md:px-32 md:pt-60 md:pb-48 lg:mx-auto lg:max-w-964 lg:px-0">
+        <article className="flex-1 px-12 pt-40 pb-68 md:px-32 md:pt-60 md:pb-48 lg:mx-auto lg:max-w-964 lg:px-0">
           <section className="flex flex-col gap-16 md:gap-32">
             <div className="flex flex-col gap-16 md:flex-row md:justify-between">
               <h2 className="text-h3/25 font-bold md:text-h1/34">


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
검색 페이지 내에서 푸터가 뜨는 스타일 오류 수정
## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
상위 태그에 flex를 적용하여, 가운데 태그를 늘렸습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #153 
## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
수정 전
![image](https://github.com/user-attachments/assets/88007565-b924-4da4-8c5c-9dfcfbf5ef70)

수정 후
![image](https://github.com/user-attachments/assets/57376f9b-257e-4148-8ab3-7d1ecde40c99)


## 💡 참고 사항