### PR TITLE
🐛 fix: 태블릿, 모바일에서 공고리스트 페이지 깨짐 오류 수정

### DIFF
--- a/src/pages/notice/NoticeList.tsx
+++ b/src/pages/notice/NoticeList.tsx
@@ -260,12 +260,12 @@ export default function NoticeList({ search = '' }: { search?: string }) {
               </div>
             </div>
             {shouldShowEmpty && allNotices.length === 0 ? (
-              <div className="flex h-728 w-964 items-center justify-center text-h3 text-black">
+              <div className="flex h-815 items-center justify-center text-h3 text-black md:h-1141 lg:h-728 lg:w-964">
                 등록된 게시물이 없습니다.
               </div>
             ) : (
               <>
-                <div className="grid h-728 grid-cols-2 gap-x-8 gap-y-16 md:gap-x-14 md:gap-y-32 lg:grid-cols-3">
+                <div className="grid h-815 grid-cols-2 gap-x-8 gap-y-16 md:h-1141 md:gap-x-14 md:gap-y-32 lg:h-728 lg:grid-cols-3">
                   {allNotices.map((notice) => (
                     <div key={notice.id} className="block">
                       <Post data={notice} />

--- a/src/pages/notice/NoticeList.tsx
+++ b/src/pages/notice/NoticeList.tsx
@@ -260,12 +260,12 @@ export default function NoticeList({ search = '' }: { search?: string }) {
               </div>
             </div>
             {shouldShowEmpty && allNotices.length === 0 ? (
-              <div className="flex h-815 items-center justify-center text-h3 text-black md:h-1141 lg:h-728 lg:w-964">
+              <div className="flex h-261 items-center justify-center text-h3 text-black md:h-1141 lg:h-728 lg:w-964">
                 등록된 게시물이 없습니다.
               </div>
             ) : (
               <>
-                <div className="grid h-815 grid-cols-2 gap-x-8 gap-y-16 md:h-1141 md:gap-x-14 md:gap-y-32 lg:h-728 lg:grid-cols-3">
+                <div className="grid grid-cols-2 gap-x-8 gap-y-16 md:h-1141 md:gap-x-14 md:gap-y-32 lg:h-728 lg:grid-cols-3">
                   {allNotices.map((notice) => (
                     <div key={notice.id} className="block">
                       <Post data={notice} />


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
태블릿, 모바일에서 공고리스트 페이지 깨짐 오류 수정

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
전체 공고 부분의 높이를 고정했습니다. (반응형)

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
- #163 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 💡 참고 사항